### PR TITLE
Adds a loader to the profile page while searching

### DIFF
--- a/components/profile/data-overlay.vue
+++ b/components/profile/data-overlay.vue
@@ -4,6 +4,7 @@ import { useRelayStore } from '@/stores/relays'
 
 const props = defineProps([
   'info',
+  'infoEvents',
   'publicKey',
   'relayData',
   'followData',

--- a/components/profile/lists-list.vue
+++ b/components/profile/lists-list.vue
@@ -1,4 +1,7 @@
 <script setup>
+import listsService from '@/helpers/listsService.js'
+import ToolBox from '@/helpers/toolBox'
+
 const props = defineProps([
   'info'
 ])
@@ -16,14 +19,32 @@ const sortedLists = computed(() => {
   })
 })
 
+const emptyLists = computed(() => {
+  const result = []
+
+  let event, tags
+  for(let i=0; i<props.info.length; i++) {
+    event = props.info[i]
+    tags = ToolBox.findTagsExcluding(event, ['d'])
+    if(!tags || tags.length == 0) {
+      result.push(event)
+    }
+  }
+
+  return result
+})
+
 const title = computed(() => {
   const count = props.info.length
   return count + ' list' + (count == 1 ? '' : 's')
 })
 
 function navigate(info) {
-  console.log('nav', info)
   emit('navigate', 'list', info)
+}
+
+function deleteEmptyLists() {
+  listsService.deleteEmptyLists(props.info)
 }
 
 </script>
@@ -32,6 +53,12 @@ function navigate(info) {
   <div v-if="info" class="lists-list">
     <ProfileSectionBack @select="$emit('back')" />
     <ProfileSectionTitle :title="title" />
+
+    <button
+      v-if="false && emptyLists.length > 0"
+      @click="deleteEmptyLists"
+    >Delete empty lists</button>
+
     <div class="lists">
       <ProfileListsItem
         v-for="(item, index) in sortedLists"

--- a/components/profile/loader.vue
+++ b/components/profile/loader.vue
@@ -1,0 +1,203 @@
+<script setup>
+/*
+
+Shows a loader and if it loads too long shows a timeout and some tips
+
+- Restart when the public key changes
+- Stop when events pop in
+
+*/
+
+const props = defineProps([
+  'status',
+  'events'
+])
+
+const steps = [
+  {
+    emoji: null,
+    copy: null,
+    timer: 2500
+  },
+  {
+    emoji: "🔎",
+    copy: "Looking...",
+    timer: 2500
+  },
+  {
+    emoji: "🕵️",
+    copy: "Investigating...",
+    timer: 2500
+  },
+  {
+    emoji: "🧐",
+    copy: "Inspecting...",
+    timer: 2500
+  },
+  {
+    emoji: "🤨",
+    copy: "Rummaging...",
+    timer: 2500
+  },
+  {
+    emoji: "🫤",
+    copy: 'Sorry, could not find a profile with the {type} <span>"{id}"</span>.',
+    timer: null
+  }
+]
+
+const errorState = {
+    emoji: "🫠",
+    copy: 'Oh no, this profile name or Id is not valid: <span>"{id}"</span>.',
+}
+
+let timerStep = ref(-1)
+let timer = null
+const copy = ref(null)
+const emoji = ref(null)
+
+watch(() => props.status, (newStatus, oldStatus) => {
+  evaluateStatus(newStatus)
+})
+
+watch(() => props.events, (newEvents, oldEvents) => {
+  if(newEvents && newEvents.length > 0) {
+    stop()
+  }
+})
+
+function evaluateStatus(status) {
+  if(status) {
+    if(status.state == 'loading') {
+      start()
+    } else if(status.state == 'loaded') {
+      stop()
+    } else if(status.state == 'error') {
+      stop()
+      showError()
+    }
+  }
+}
+
+function start() {
+  timerStep.value = -1
+  nextStep()
+}
+
+function stop() {
+  clearTimeout(timer)
+  emoji.value = null
+  copy.value = null
+}
+
+function showError() {
+  clearTimeout(timer)
+  displayInfo(errorState, props.status)
+}
+
+function displayInfo(info, data) {
+  emoji.value = info.emoji
+
+  let copyText = info.copy
+  if(copyText) {
+    const replace = {}
+    if(data.npub) {
+      replace.type = 'npub'
+      replace.id = data.npub
+    } else if(data.nprofile) {
+      replace.type = 'nprofile'
+      replace.id = data.nprofile
+    } else if(data.nip05) {
+      replace.type = 'nip05'
+      replace.id = data.nip05
+    } else if(data.publicKey) {
+      replace.type = 'publicKey'
+      replace.id = data.publicKey
+    }
+
+    for(let i in replace) {
+      copyText = copyText.split('{'+i+'}').join(replace[i])
+    }
+  }
+  copy.value = copyText
+}
+
+function nextStep() {
+  clearTimeout(timer)
+
+  if(timerStep.value < (steps.length-1)) {
+    timerStep.value = timerStep.value + 1
+
+    const step = steps[timerStep.value]
+
+    displayInfo(step, props.status)
+
+    if(step.timer) {
+      timer = setTimeout(nextStep, step.timer)
+    }
+  }
+}
+
+const statusId = computed(() => {
+  let result = 'default_'+timerStep.value
+
+  if(props.status) {
+    for(let i in props.status) {
+      result += '_'+i+'_'+props.status[i]
+    }
+  }
+
+  return result
+})
+
+onMounted(() => {
+  evaluateStatus(props.status)
+})
+</script>
+
+<template>
+  <Transition name="fade" :key="statusId" :tets="statusId" appear>
+    <div v-if="copy" class="profile-loader">
+      <p v-if="emoji">{{ emoji }}</p>
+      <p v-html="copy" />
+    </div>
+  </Transition>
+</template>
+
+<style scoped lang="scss">
+
+.profile-loader {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 75px;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+
+  p {
+    text-align: center;
+
+    &:first-child {
+      font-size: 48px;
+    }
+
+    &:nth-child(2) {
+      margin-top: 15px;
+      font-size: 15px;
+      line-height: 1.6;
+      font-weight: 600;
+      color: rgba(var(--theme-front-rgb), 0.75);
+
+      :deep(span) {
+        word-break: break-all;
+        color: var(--theme-front);
+      }
+    }
+  }
+}
+
+</style>

--- a/helpers/create/relayPublisher.js
+++ b/helpers/create/relayPublisher.js
@@ -2,7 +2,7 @@ import relayPublishRequest from '@/helpers/relayPublishRequest.js'
 import { useProfileStore } from '@/stores/profile'
 import relayManager from '@/helpers/relayManager.js'
 
-export default function metaPublisher () { 
+export default function relayPublisher () { 
   return {
     store: null,
     callback: null,

--- a/helpers/listsService.js
+++ b/helpers/listsService.js
@@ -1,0 +1,129 @@
+import relayPublishRequest from '@/helpers/relayPublishRequest.js'
+import { useSessionStore } from '@/stores/session'
+import ToolBox from '@/helpers/toolBox'
+
+
+/*
+
+Helps with some list-related things
+- Picking out empty lists from an array of list events, and publishing delete requests
+
+TODO: Need to show a confirm modal to ask users if they are sure.
+TODO: Communicate that deletion is not guaranteed, the relay doesn't have to.
+TODO: Hide deleted relays from the UI, or annotate them as deleted
+
+ */
+
+export default {
+  log: false,
+  sessionStore: null,
+  groupedLists: null,
+  requestQueue: null,
+
+  deleteEmptyLists(lists) {
+    if(this.log) console.log('ListsService.deleteEmptyLists', lists)
+
+    // Group by relay
+    const emptyLists = this.findEmptyLists(lists)
+    const groupedLists = {}
+    let i=0, list
+    for(; i<emptyLists.length; i++) {
+      list = emptyLists[i]
+      if(!groupedLists[list.relay]) {
+        groupedLists[list.relay] = []
+      }
+      groupedLists[list.relay].push(list)
+    }
+
+    this.requestQueue = {}
+    this.groupedLists = groupedLists
+    this.requestQueue = Object.keys(groupedLists)
+    
+    this.requestNextDeletion()
+  },
+
+  requestNextDeletion() {
+    if(this.requestQueue && this.requestQueue.length > 0) {
+      const relayId = this.requestQueue[0]
+      this.requestQueue.splice(0, 1)
+      const lists = this.groupedLists[relayId]
+
+      this.deleteEmptyListsByRelay(relayId, lists)
+    }
+  },
+
+  findEmptyLists(lists) {
+    const result = []
+
+    let event, tags
+    for(let i=0; i<lists.length; i++) {
+      event = lists[i]
+      tags = ToolBox.findTagsExcluding(event, ['d'])
+      if(!tags || tags.length == 0) {
+        result.push(event)
+      }
+    }
+
+    if(this.log) console.log('ListsService.findEmptyLists', result)
+
+    return result
+  },
+
+  deleteEmptyListsByRelay(relayId, lists) {
+    if(this.log) console.log('ListsService.deleteEmptyListsByRelay', relayId, lists)
+
+    if(!this.sessionStore) {
+      this.sessionStore = useSessionStore()
+    }
+
+    const event = {
+      pubkey: this.sessionStore.publicKey,
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 5,
+      content: '',
+      tags: []
+    }
+
+    let i=0, list
+    for(; i<lists.length; i++) {
+      list = lists[i]
+      event.tags.push(['e', list.id])
+    }
+
+    event.id = window.NostrTools.getEventHash(event)
+    if(this.log) console.log('ListsService.event', relayId, event)
+    // event.sig = window.NostrTools.signEvent(event, this.store.privateKey)
+
+    // Sign the event via the browser
+
+    const ref = this
+    window.nostr.enable()
+      .then(() => {
+        if(this.log) console.log('ListsService.enable worked', event)
+
+        window.nostr.signEvent(event)
+          .then((signedEvent) => {
+            if(this.log) console.log('ListsService.signEvent worked', signedEvent, relayId, ref.onDeleteEmptyList)
+            // return
+            const request = relayPublishRequest()
+            request.publish(
+              relayId,
+              signedEvent,
+              onDeleteEmptyLists
+            )
+            
+            ref.requestNextDeletion()
+          })
+          .catch((relayId, event) => {
+            console.log('signEvent failed')
+          })
+      })
+      .catch(() => {
+        console.log('enable failed', arguments)
+      })
+  },
+
+  onDeleteEmptyList(status) {
+    if(this.log) console.log('ListsService.onDeleteEmptyList', status)
+  }
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,41 +1,46 @@
 {
- "name": "App",
- "icons": [
-  {
-   "src": "\/android-icon-36x36.png",
-   "sizes": "36x36",
-   "type": "image\/png",
-   "density": "0.75"
-  },
-  {
-   "src": "\/android-icon-48x48.png",
-   "sizes": "48x48",
-   "type": "image\/png",
-   "density": "1.0"
-  },
-  {
-   "src": "\/android-icon-72x72.png",
-   "sizes": "72x72",
-   "type": "image\/png",
-   "density": "1.5"
-  },
-  {
-   "src": "\/android-icon-96x96.png",
-   "sizes": "96x96",
-   "type": "image\/png",
-   "density": "2.0"
-  },
-  {
-   "src": "\/android-icon-144x144.png",
-   "sizes": "144x144",
-   "type": "image\/png",
-   "density": "3.0"
-  },
-  {
-   "src": "\/android-icon-192x192.png",
-   "sizes": "192x192",
-   "type": "image\/png",
-   "density": "4.0"
-  }
- ]
+    "name": "Nosta",
+    "short_name": "Nosta",
+    "description": "Represent your vibe on Nostr.",
+    "categories": ["social networking", "utilities"],
+    "start_url": "/",
+    "display": "standalone",
+    "icons": [
+        {
+            "src": "\/images/android-icon-36x36.png",
+            "sizes": "36x36",
+            "type": "image\/png",
+            "density": "0.75"
+        },
+        {
+            "src": "\/images/android-icon-48x48.png",
+            "sizes": "48x48",
+            "type": "image\/png",
+            "density": "1.0"
+        },
+        {
+            "src": "\/images/android-icon-72x72.png",
+            "sizes": "72x72",
+            "type": "image\/png",
+            "density": "1.5"
+        },
+        {
+            "src": "\/images/android-icon-96x96.png",
+            "sizes": "96x96",
+            "type": "image\/png",
+            "density": "2.0"
+        },
+        {
+            "src": "\/images/android-icon-144x144.png",
+            "sizes": "144x144",
+            "type": "image\/png",
+            "density": "3.0"
+        },
+        {
+            "src": "\/images/android-icon-192x192.png",
+            "sizes": "192x192",
+            "type": "image\/png",
+            "density": "4.0"
+        }
+    ]
 }


### PR DESCRIPTION
It cycles through some emoji and copy, just for fun. One thing missing is to give the user some practical options on what to do next when no profile info was found. This could be searching more relays, editing the ID (npub, nprofile...), or maybe something else. Don't want to dead-end people.

There's also functionality in there for deleting empty lists. Iris currently tracks when you checked your notifications or chats via empty lists, which creates a ton of spam events. This is a quick way to delete them. It's hidden because it was for testing and needs to be properly implemented.