### PR TITLE
Minor fixes via Karnage

### DIFF
--- a/components/create/review-item.vue
+++ b/components/create/review-item.vue
@@ -85,6 +85,8 @@ function formatAddedCount(list, singular, plural) {
     &:nth-child(2n) {
       flex-grow: 1;
       text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
     }
   }
 

--- a/pages/create/handle-enter.vue
+++ b/pages/create/handle-enter.vue
@@ -31,6 +31,10 @@ const isValidEmail = computed(() => {
   return containsAt && containsDot && longEnough
 })
 
+watch(() => store.handle, (newValue, oldValue) => {
+  handleCheckStatus.value = null
+})
+
 const inputValid = computed(() => {
   const hasValidInput = store.handle.length > 5 ? isValidEmail.value : true
   return !hasInput.value || (hasValidInput && handleCheckStatus.value == 'valid')
@@ -86,7 +90,11 @@ async function loadNip05(handle) {
   try {
     const data = await window.NostrTools.nip05.queryProfile(cleanHandle)
 
-    handleCheckStatus.value = 'valid'
+    if(data) {
+      handleCheckStatus.value = 'valid'
+    } else {
+      handleCheckStatus.value = 'not-found'
+    }
   } catch(error) {
     handleCheckStatus.value = 'not-found'
   }

--- a/pages/create/picture-enter.vue
+++ b/pages/create/picture-enter.vue
@@ -10,7 +10,6 @@ We want the user to only move forward with valid input
 
 Image is valid if it's been successfully loaded
 
-
  */
 
 import { useProfileStore } from '@/stores/profile'
@@ -178,7 +177,7 @@ onMounted(() => {
       <UiButton 
         @click="loadImage"
         size="small"
-      >Load image</UiButton>
+      >Preview image</UiButton>
     </div>
     <nav>
       <UiButton 

--- a/pages/create/recovery-phrase-verify.vue
+++ b/pages/create/recovery-phrase-verify.vue
@@ -41,8 +41,8 @@ onMounted(() => {
     <div class="content">
       <div class="copy">
         <p class="-step">4 of 10</p>
-        <h1>Your recovery phrase</h1>
-        <p class="-description">These words let you recreate your private and public keys. Write them down in a safe place.</p>
+        <h1>Let's check</h1>
+        <p class="-description">Tap the words in the order they appear in your recovery phrase.</p>
       </div>
     </div>
     <div class="options">

--- a/pages/create/review.vue
+++ b/pages/create/review.vue
@@ -89,6 +89,7 @@ const store = useProfileStore()
     // justify-content: flex-start !important;
     // overflow-y: scroll;
     align-items: stretch !important;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
[Karnage](https://nosta.me/nprofile1qqsph3c2q9yt8uckmgelu0yf7glruudvfluesqn7cuftjpwdynm2gygpz3mhxue69uhhyetvv9ujuerpd46hxtnfducms3fc?t=black) sent me a 40 minute video (huge thanks) walking through the whole experience with a ton of valuable feedback. This update includes a few quick fixes:

- Add proper copy to the recovery phrase verification page (was totally the wrong copy, no clue how I didn't catch that earlier)
- Fixed NIP05 checking on the handle page (don't just check for errors, also check for empty data returns)
- Change button label on the picture page for clarity ("Load image" -> "Preview image")
- Fixed text ellipsis CSS on the review page to prevent layout breaks

More to come. Just getting a few things out that were problematic and easy to address.