### PR TITLE
Log user in on profile creation save page

### DIFF
--- a/components/header/account.vue
+++ b/components/header/account.vue
@@ -1,22 +1,17 @@
 <script setup>
+import { storeToRefs } from 'pinia'
 import { useSessionStore } from '@/stores/session'
 
 const sessionStore = useSessionStore()
 
+const { isLoggedIn } = storeToRefs(sessionStore);
+
 const title = computed(() => {
-  if(sessionStore.isLoggedIn) {
-    return 'View profile'
-  } else {
-    return 'Sign in'
-  }
+  return isLoggedIn ? 'View profile' : 'Sign in'
 })
 
 const link = computed(() => {
-  if(sessionStore.isLoggedIn) {
-    return '/'+sessionStore.publicKey
-  } else {
-    return '/login/options'
-  }
+  return isLoggedIn ? '/'+sessionStore.publicKey : '/login/options'
 })
 </script>
 

--- a/components/header/account.vue
+++ b/components/header/account.vue
@@ -4,7 +4,7 @@ import { useSessionStore } from '@/stores/session'
 
 const sessionStore = useSessionStore()
 
-const { isLoggedIn } = storeToRefs(sessionStore);
+const { isLoggedIn } = storeToRefs(sessionStore)
 
 const title = computed(() => {
   return isLoggedIn ? 'View profile' : 'Sign in'

--- a/pages/create/save.vue
+++ b/pages/create/save.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { useProfileStore } from '@/stores/profile'
+import { useSessionStore } from '@/stores/session'
 import profilePublisher from '@/helpers/create/profilePublisher.js'
 import profileInitializer from '@/helpers/create/profileInitializer.js'
 import Icons from '@/helpers/icons'
@@ -22,6 +23,7 @@ definePageMeta({
 
 const router = useRouter()
 const store = useProfileStore()
+const sessionStore = useSessionStore()
 const state = ref('default')
 const saveStart = ref(null)
 let publisher = null
@@ -79,10 +81,22 @@ function onTimer() {
 
 function onSaveSuccess() {
   state.value = 'success'
+
+  login()
 }
 
 function onSaveError() {
   state.value = 'error'
+
+  // Log user in anyways.
+  login()
+}
+
+function login() {
+  sessionStore.setLoginType('privatekey')
+  sessionStore.setPrivateKey(store.privateKey)
+  sessionStore.setPublicKey(store.publicKey)
+  sessionStore.setLoggedIn(true)
 }
 
 const optionsClass = computed(() => {
@@ -139,6 +153,8 @@ const buttonLabel = computed(() => {
 
 onMounted(() => {
   profileInitializer.init()
+
+  login()
 })
 </script>
 

--- a/stores/session.js
+++ b/stores/session.js
@@ -42,7 +42,6 @@ export const useSessionStore = defineStore('session', {
     },
 
     setLoggedIn(value) {
-      // console.log('useSessionStore.setLoggedIn', this.isLoggedIn)
       this.isLoggedIn = value
     },
 


### PR DESCRIPTION
Bit of a big oversight here. The user should obviously be logged in after setting up their profile. This has not been the case so far. This is part of #59.