### PR TITLE
Adding link helper class

### DIFF
--- a/components/profile/badge/item.vue
+++ b/components/profile/badge/item.vue
@@ -2,9 +2,11 @@
 import relayRequest from '@/helpers/relayRequest.js'
 import multiRelayRequest from '@/helpers/multiRelayRequest.js'
 import { useRelayStore } from '@/stores/relays'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 let rawBadgeData = null
@@ -116,14 +118,18 @@ const link = computed(() => {
 
     const relay = relayStore.getRelay(rawBadgeData.relay)
 
-    const naddr = window.NostrTools.nip19.naddrEncode({
-      kind: bits[0],
-      pubkey: bits[1],
-      identifier: bits[2],
-      relays: [relay.url]
-    })
+    const url = linkHelper.address(
+      bits[2],
+      bits[1], 
+      bits[0],
+      relay.url,
+      props.handlers,
+      linkHelper.badges.badge
+    )
 
-    result = 'https://badges.page/b/' + naddr
+    if(url) {
+      result = url
+    }
   }
 
   return result

--- a/components/profile/badge/list.vue
+++ b/components/profile/badge/list.vue
@@ -1,7 +1,8 @@
 <script setup>
 const props = defineProps([
   'info',
-  'profileService'
+  'profileService',
+  'handlers'
 ])
 
 const emit = defineEmits(['back'])
@@ -25,6 +26,7 @@ const title = computed(() => {
           v-for="(item, index) in info"
           :key="item.id"
           :info="item"
+          :handlers="handlers"
         />
       </div>
     </div>

--- a/components/profile/badge/summary.vue
+++ b/components/profile/badge/summary.vue
@@ -4,17 +4,13 @@ import Icons from '@/helpers/icons'
 const props = defineProps([
   'info',
   'count',
-  'baseUrl'
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate'])
 
 const visibleBadges =  computed(() => {
   return props.count > 0 ? props.info.slice(0, 5) : null
-})
-
-const detailUrl = computed(() => {
-  return props.baseUrl + '/badges'
 })
 
 const titleCopy = computed(() => {
@@ -45,6 +41,7 @@ function navigate() {
           v-for="(item, index) in visibleBadges"
           :key="item.id"
           :info="item"
+          :handlers="handlers"
         />
       </div>
     </div>

--- a/components/profile/bits/note.vue
+++ b/components/profile/bits/note.vue
@@ -175,7 +175,7 @@ function turnNAddrToNode(text) {
 function turnVideoToNode(text, extension) {
   const props = { controls: true }
   const meta = findUrlMeta(text)
-  if(meta.width && meta.height) {
+  if(meta && meta.width && meta.height) {
     props.style = {
       aspectRatio: Math.round(meta.width/meta.height*100)/100
     }

--- a/components/profile/calendar/item.vue
+++ b/components/profile/calendar/item.vue
@@ -2,11 +2,13 @@
 import { useRelayStore } from '@/stores/relays'
 import ToolBox from '@/helpers/toolBox'
 import Icons from '@/helpers/icons'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const relayStore = useRelayStore()
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const title = computed(() => {
@@ -56,24 +58,20 @@ const link = computed(() => {
   const tag = ToolBox.findTag(props.info, 'd')
   const relay = relayStore.getRelay(props.info.relay)
 
-  const data = {
-    kind: 30311,
-    pubkey: props.info.pubkey,
-    identifier: tag[0],
-    relays: [relay.url]
-  }
-
-  return 'https://www.flockstr.com/calendar/' + window.NostrTools.nip19.naddrEncode(data)
+  return linkHelper.address(
+    tag[0],
+    props.info.pubkey, 
+    props.info.kind,
+    relay.url,
+    props.handlers,
+    linkHelper.flockstr.calendar
+  )
 })
 
 const classObject = computed(() => {
   const c = ['calendar-item']
 
   return c.join(' ')
-})
-
-onBeforeMount(() => {
-  console.log('event list calendar item', props.info)
 })
 </script>
 

--- a/components/profile/calendar/list.vue
+++ b/components/profile/calendar/list.vue
@@ -2,7 +2,8 @@
 import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate', 'back'])
@@ -64,6 +65,7 @@ function navigate(info) {
       v-for="(item, index) in info"
       :key="item.id"
       :info="item"
+      :handlers="handlers"
     />
   </div>
 </template>

--- a/components/profile/calendar/summary.vue
+++ b/components/profile/calendar/summary.vue
@@ -5,7 +5,7 @@ import ToolBox from '@/helpers/toolBox'
 const props = defineProps([
   'info',
   'count',
-  'baseUrl'
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate'])
@@ -40,6 +40,7 @@ function navigate() {
       <ProfileCalendarList
         class="items"
         :info="visibleItems"
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/calendar/tab.vue
+++ b/components/profile/calendar/tab.vue
@@ -2,7 +2,8 @@
 import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['back'])
@@ -24,6 +25,7 @@ const title = computed(() => {
       <ProfileCalendarList
         class="items"
         :info="info" 
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/classifieds/item.vue
+++ b/components/profile/classifieds/item.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { useRelayStore } from '@/stores/relays'
 import ToolBox from '@/helpers/toolBox'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const relayStore = useRelayStore()
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const title = computed(() => {
@@ -52,14 +54,14 @@ const link = computed(() => {
   const tag = props.info.tags.find(tag => tag[0] == 'd')
   const relay = relayStore.getRelay(props.info.relay)
 
-  const data = {
-    kind: 30402,
-    pubkey: props.info.pubkey,
-    identifier: tag[1],
-    relays: [relay.url]
-  }
-
-  return 'https://ostrich.work/jobs/' + window.NostrTools.nip19.naddrEncode(data)
+  return linkHelper.address(
+    tag[1], 
+    props.info.pubkey,
+    props.info.kind,
+    relay.url,
+    props.handlers,
+    linkHelper.ostrich.job
+  )
 })
 
 const formattedDate = computed(() => {

--- a/components/profile/classifieds/list.vue
+++ b/components/profile/classifieds/list.vue
@@ -1,6 +1,7 @@
 <script setup>
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate', 'back'])
@@ -21,6 +22,7 @@ function navigate(info) {
       v-for="(item, index) in info"
       :key="item.id"
       :info="item"
+      :handlers="handlers"
     />
   </div>
 </template>

--- a/components/profile/classifieds/summary.vue
+++ b/components/profile/classifieds/summary.vue
@@ -4,7 +4,8 @@ import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
   'info',
-  'count'
+  'count',
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate'])
@@ -39,6 +40,7 @@ function navigate() {
       <ProfileClassifiedsList
         class="items"
         :info="visibleItems"
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/classifieds/tab.vue
+++ b/components/profile/classifieds/tab.vue
@@ -2,7 +2,8 @@
 import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['back'])
@@ -24,6 +25,7 @@ const title = computed(() => {
       <ProfileClassifiedsList
         class="items"
         :info="info" 
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/event/item.vue
+++ b/components/profile/event/item.vue
@@ -2,11 +2,13 @@
 import { useRelayStore } from '@/stores/relays'
 import ToolBox from '@/helpers/toolBox'
 import Icons from '@/helpers/icons'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const relayStore = useRelayStore()
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const title = computed(() => {
@@ -118,14 +120,14 @@ const link = computed(() => {
   const tag = ToolBox.findTag(props.info, 'd')
   const relay = relayStore.getRelay(props.info.relay)
 
-  const data = {
-    kind: 30311,
-    pubkey: props.info.pubkey,
-    identifier: tag[0],
-    relays: [relay.url]
-  }
-
-  return 'https://www.flockstr.com/article/' + window.NostrTools.nip19.naddrEncode(data)
+  return linkHelper.address(
+    tag[0],
+    props.info.pubkey, 
+    props.info.kind,
+    relay.url,
+    props.handlers,
+    linkHelper.flockstr.event
+  )
 })
 
 const classObject = computed(() => {

--- a/components/profile/event/list.vue
+++ b/components/profile/event/list.vue
@@ -2,7 +2,8 @@
 import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate', 'back'])
@@ -64,6 +65,7 @@ function navigate(info) {
       v-for="(item, index) in sortedInfo"
       :key="item.id"
       :info="item"
+      :handlers="handlers"
     />
   </div>
 </template>

--- a/components/profile/event/summary.vue
+++ b/components/profile/event/summary.vue
@@ -5,7 +5,7 @@ import ToolBox from '@/helpers/toolBox'
 const props = defineProps([
   'info',
   'count',
-  'baseUrl'
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate'])
@@ -40,6 +40,7 @@ function navigate() {
       <ProfileEventList
         class="items"
         :info="visibleItems"
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/event/tab.vue
+++ b/components/profile/event/tab.vue
@@ -3,7 +3,7 @@ import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
   'info',
-  'calendars'
+  'handlers'
 ])
 
 const emit = defineEmits(['back'])
@@ -22,13 +22,10 @@ const title = computed(() => {
     <div v-if="info" class="events-tab">
       <ProfileSectionBack @select="$emit('back')" />
       <ProfileSectionTitle :title="title" />
-      <ProfileEventCalendarList
+      <ProfileEventList
         class="items"
-        :info="calendars" 
-      />
-      <ProfileEventEventList
-        class="items"
-        :info="info" 
+        :info="info"
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/info.vue
+++ b/components/profile/info.vue
@@ -227,7 +227,7 @@ function showDataOverlay() {
       @include r('font-size', 40, 64);
       color: var(--theme-text-bright);
       word-break: break-word;
-      white-space: nowrap;
+      // white-space: nowrap;
     }
 
     .user-status {
@@ -240,6 +240,7 @@ function showDataOverlay() {
       color: var(--theme-text-medium);
       text-wrap: balance;
       word-wrap: break-word;
+      white-space: normal;
 
       :deep(a) {
         color: var(--theme-text-medium);

--- a/components/profile/live/item.vue
+++ b/components/profile/live/item.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { useRelayStore } from '@/stores/relays'
 import ToolBox from '@/helpers/toolBox'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const relayStore = useRelayStore()
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const title = computed(() => {
@@ -52,14 +54,14 @@ const link = computed(() => {
   const tag = ToolBox.findTag(props.info, 'd')
   const relay = relayStore.getRelay(props.info.relay)
 
-  const data = {
-    kind: 30311,
-    pubkey: props.info.pubkey,
-    identifier: tag[0],
-    relays: [relay.url]
-  }
-
-  return 'https://zap.stream/' + window.NostrTools.nip19.naddrEncode(data)
+  return linkHelper.address(
+    tag[0], 
+    props.info.pubkey,
+    props.info.kind,
+    relay.url,
+    props.handlers,
+    linkHelper.zap.stream
+  )
 })
 
 const classObject = computed(() => {

--- a/components/profile/live/list.vue
+++ b/components/profile/live/list.vue
@@ -1,6 +1,7 @@
 <script setup>
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate', 'back'])
@@ -21,6 +22,7 @@ function navigate(info) {
       v-for="(item, index) in info"
       :key="item.id"
       :info="item"
+      :handlers="handlers"
     />
   </div>
 </template>

--- a/components/profile/live/summary.vue
+++ b/components/profile/live/summary.vue
@@ -5,7 +5,7 @@ import ToolBox from '@/helpers/toolBox'
 const props = defineProps([
   'info',
   'count',
-  'baseUrl'
+  'handlers'
 ])
 
 const emit = defineEmits(['navigate'])
@@ -40,6 +40,7 @@ function navigate() {
       <ProfileLiveList
         class="items"
         :info="visibleItems"
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/live/tab.vue
+++ b/components/profile/live/tab.vue
@@ -2,7 +2,8 @@
 import ToolBox from '@/helpers/toolBox'
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const emit = defineEmits(['back'])
@@ -24,6 +25,7 @@ const title = computed(() => {
       <ProfileLiveList
         class="items"
         :info="info" 
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/long-notes/item.vue
+++ b/components/profile/long-notes/item.vue
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia'
 import ToolBox from '@/helpers/toolBox'
 import { useHandlerStore } from "@/stores/handlers.js"
 import { useRelayStore } from '@/stores/relays'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const handlerStore = useHandlerStore()
 const relayStore = useRelayStore()
@@ -10,7 +11,8 @@ const relayStore = useRelayStore()
 const { handlers } = storeToRefs(handlerStore)
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const title = computed(() => {
@@ -41,19 +43,14 @@ const url = computed(() => {
   const relay = relayStore.getRelay(props.info.relay)
   const identifierTag = props.info.tags.find(tag => tag[0] == 'd')
 
-  const data = {
-    kind: props.info.kind+'',
-    identifier: identifierTag[1],
-    pubkey: props.info.pubkey,
-    relays: [relay.url]
-  }
-  const bech = window.NostrTools.nip19.naddrEncode(data)
-
-  if(handler.value) {
-    return handler.value.replace('<bech32>', bech)
-  } else {
-    return 'https://habla.news/a/' + bech
-  }
+  return linkHelper.address(
+    identifierTag[1],
+    props.info.pubkey, 
+    props.info.kind,
+    relay.url,
+    props.handlers,
+    linkHelper.habla.address
+  )
 })
 
 const summary = computed(() => {
@@ -93,29 +90,6 @@ const tags = computed(() => {
 
     if(result.length > 5) {
       result = result.slice(0, 5)
-    }
-  }
-
-  return result
-})
-
-// See if the profile has defined a preferred handler for short notes.
-// TODO: Fallback to the logged in users preferred handler
-// TODO: Make this platform specific (on iOS, look for iOS handlers)
-const handler = computed(() => {
-  let result = null
-
-  let handler, kindTag, eventTag
-  for(let id in handlers.value) {
-    handler = handlers.value[id]
-
-
-    kindTag = handler.tags.find(tag => tag[0] == 'k' && tag[1] == '30023')
-    eventTag = handler.tags.find(tag => tag[0] == 'web' && tag[2] == 'naddr')
-
-    if(kindTag && eventTag) {
-      result = eventTag[1]
-      break
     }
   }
 

--- a/components/profile/long-notes/summary.vue
+++ b/components/profile/long-notes/summary.vue
@@ -3,7 +3,8 @@ import relayManager from '@/helpers/relayManager.js'
 
 const props = defineProps([
   'info',
-  'count'
+  'count',
+  'handlers'
 ])
 
 const latestNote = computed(() => {
@@ -34,6 +35,7 @@ const latestNote = computed(() => {
       <ProfileLongNotesItem
         :key="latestNote.id"
         :info="latestNote"
+        :handlers="handlers"
       />
     </div>
   </Transition>

--- a/components/profile/short-notes/item.vue
+++ b/components/profile/short-notes/item.vue
@@ -3,14 +3,16 @@ import { storeToRefs } from 'pinia'
 import ToolBox from '@/helpers/toolBox'
 import { useHandlerStore } from "@/stores/handlers.js"
 import { useRelayStore } from '@/stores/relays'
+import linkHelper from '@/helpers/linkHelper.js'
 
 const handlerStore = useHandlerStore()
 const relayStore = useRelayStore()
 
-const { handlers } = storeToRefs(handlerStore)
+// const { handlers } = storeToRefs(handlerStore)
 
 const props = defineProps([
-  'info'
+  'info',
+  'handlers'
 ])
 
 const created = computed(() => {
@@ -18,25 +20,24 @@ const created = computed(() => {
 })
 
 const url = computed(() => {
-  return 'https://primal.net/e/' + props.info.id
+  const relay = relayStore.getRelay(props.info.relay)
+
+  return linkHelper.event(
+    props.info.id, 
+    relay.url,
+    props.info.kind, 
+    props.handlers,
+    linkHelper.primal.event
+  )
 })
 
 const parentNote = computed(() => {
   let result = null
   
+  // TODO: Check if there's a tag with 'root'
   const tags = props.info.tags.filter(tag => tag[0] == 'e')
   if(tags.length > 0) {
     result = tags[0]
-  }
-
-  return result
-})
-
-const parentNoteUrl = computed(() => {
-  let result = null
-  
-  if(parentNote.value) {
-    result = 'https://primal.net/e/' + parentNote.value[1]
   }
 
   return result
@@ -53,34 +54,18 @@ const previousNote = computed(() => {
   return result
 })
 
-const previousNoteUrl = computed(() => {
-  let result = null
-  
-  if(previousNote.value) {
-    result = 'https://primal.net/e/' + previousNote.value[1]
-  }
-
-  return result
-})
-
 const threadTags = computed(() => {
   const result = []
   
   let url, bech, relay
   if(parentNote.value) {
-    relay = relayStore.getRelay(props.info.relay)
-
-    bech = window.NostrTools.nip19.neventEncode({
-      id: parentNote.value[1],
-      relays: [relay.url],
-      kind: 1
-    })
-
-    if(handler.value) {
-      url = handler.value.replace('<bech32>', bech)
-    } else {
-      url = 'https://primal.net/e/' + parentNote.value[1]
-    }
+    url = linkHelper.event(
+      parentNote.value[1], 
+      parentNote.value[2],
+      1, 
+      props.handlers,
+      linkHelper.primal.event
+    )
 
     result.push({
       name: 'Thread',
@@ -91,19 +76,13 @@ const threadTags = computed(() => {
   }
   
   if(previousNote.value) {
-    relay = relayStore.getRelay(props.info.relay)
-
-    bech = window.NostrTools.nip19.neventEncode({
-      id: previousNote.value[1],
-      relays: [relay.url],
-      kind: 1
-    })
-
-    if(handler.value) {
-      url = handler.value.replace('<bech32>', bech)
-    } else {
-      url = 'https://primal.net/e/' + previousNote.value[1]
-    }
+    url = linkHelper.event(
+      previousNote.value[1], 
+      previousNote.value[2],
+      1, 
+      props.handlers,
+      linkHelper.primal.event
+    )
 
     result.push({
       name: 'Parent',
@@ -111,28 +90,6 @@ const threadTags = computed(() => {
       target: '_blank',
       rel: 'nofollow noopener noreferrer'
     })
-  }
-
-  return result
-})
-
-// See if the profile has defined a preferred handler for short notes.
-// TODO: Fallback to the logged in users preferred handler
-// TODO: Make this platform specific (on iOS, look for iOS handlers)
-const handler = computed(() => {
-  let result = null
-
-  let handler, kindTag, eventTag
-  for(let id in handlers.value) {
-    handler = handlers.value[id]
-
-    kindTag = handler.tags.find(tag => tag[0] == 'k' && tag[1] == '1')
-    eventTag = handler.tags.find(tag => tag[0] == 'web' && tag[2] == 'nevent')
-
-    if(kindTag && eventTag) {
-      result = eventTag[1]
-      break
-    }
   }
 
   return result

--- a/components/profile/short-notes/summary.vue
+++ b/components/profile/short-notes/summary.vue
@@ -3,7 +3,8 @@ import relayManager from '@/helpers/relayManager.js'
 
 const props = defineProps([
   'info',
-  'count'
+  'count',
+  'handlers'
 ])
 
 const latestNote = computed(() => {
@@ -64,6 +65,7 @@ const titleUrl = computed(() => {
           v-for="item in latestNotes"
           :key="item.id"
           :info="item"
+          :handlers="handlers"
         />
       </div>
     </div>

--- a/helpers/browserHelper.js
+++ b/helpers/browserHelper.js
@@ -1,10 +1,8 @@
-
 /*
 
-Loads profiles from a kind 3 event.
+For interacting with an extension
 
  */
-
 export default { 
   log: !false,
 

--- a/helpers/linkHelper.js
+++ b/helpers/linkHelper.js
@@ -1,0 +1,180 @@
+/*
+
+Constructs link notes to external clients.
+Considers preferred handlers.
+
+https://github.com/nostr-protocol/nips/blob/master/89.md
+
+Information example:
+{
+    "kind": 31990,
+    "pubkey": <pubkey>,
+    "content": "<optional-kind:0-style-metadata>",
+    "tags": [
+        [ "d", <random-id> ],
+        [ "k", <supported-event-kind> ],
+        [ "web", "https://..../a/<bech32>", "nevent" ],
+        [ "web", "https://..../p/<bech32>", "nprofile" ],
+        [ "web", "https://..../e/<bech32>" ],
+        [ "ios", ".../<bech32>" ]
+    ]
+}
+
+ */
+
+import { useRelayStore } from '@/stores/relays'
+import { useHandlerStore } from '@/stores/handlers'
+
+export default { 
+  log: false,
+  handlerStore: null,
+
+  primal: {
+    profile: 'https://primal.net/p/<bech32>',
+    event: 'https://primal.net/e/<bech32>',
+  },
+
+  habla: {
+    address: 'https://habla.news/a/<bech32>'
+  },
+
+  flockstr: {
+    event: 'https://www.flockstr.com/event/<bech32>',
+    calendar: 'https://www.flockstr.com/calendar/<bech32>'
+  },
+
+  badges: {
+    badge: 'https://badges.page/b/<bech32>',
+  },
+
+  ostrich: {
+    job: 'https://ostrich.work/jobs/<bech32>',
+  },
+
+  zap: {
+    stream: 'https://zap.stream/<bech32>'
+  },
+
+  address(eventId, authorPubkey, eventKind, eventRelay, handlers, fallbackUrl) {
+    const platform = 'web'
+    const linkType = 'naddr'
+
+    if(this.log) console.log('event', eventId, authorPubkey, eventKind, eventRelay, handlers)
+
+    const bech = window.NostrTools.nip19.naddrEncode({
+      kind: eventKind+'',
+      identifier: eventId,
+      pubkey: authorPubkey,
+      relays: [eventRelay]
+    })
+
+    const handlerUrl = this.findMatchingHandler(handlers, platform, eventKind, linkType, fallbackUrl)
+
+    const url = handlerUrl.replace('<bech32>', bech)
+
+    if(this.log) console.log('handlerUrl', handlerUrl)
+    if(this.log) console.log('url', url)
+
+    return url
+  },
+
+  event(eventId, eventRelay, eventKind, handlers, fallbackUrl) {
+    const platform = 'web'
+    const linkType = 'nevent'
+
+    if(this.log) console.log('event', eventId, eventRelay, eventKind, handlers)
+
+    const bech = window.NostrTools.nip19.neventEncode({
+      id: eventId,
+      relays: [eventRelay],
+      kind: eventKind
+    })
+
+    const handlerUrl = this.findMatchingHandler(handlers, platform, eventKind, linkType, fallbackUrl)
+
+    const url = handlerUrl.replace('<bech32>', bech)
+
+    if(this.log) console.log('handlerUrl', handlerUrl)
+    if(this.log) console.log('url', url)
+
+    return url
+  },
+
+  /*
+    This is such a wreck.
+
+    1. Filter recommendations by ones that have matching kinds and platforms
+    2. Extract the pubkeys of the handlers from the tags in those recommendations
+    3. Get matching handlers for the pubkeys from the store
+    4. Find the first of those handers that has a URL template for the link type we want
+  
+    Find a way to optimize this instead of running it dozens of times
+    Maybe create an index of these as the handlers and recommendations are loaded
+    Or cache them?
+   */
+  findMatchingHandler(handlers, platform, eventKind, linkType, fallbackUrl) {
+    let result = fallbackUrl
+
+    if(handlers) {
+      // Filter handler recommendations by ones that support the kind and platform we want
+      const kindHandlers = handlers.filter((handler) => {
+        const kindTag = handler.tags.find(tag => tag[0] == 'd' && tag[1] == eventKind+'')
+        if(kindTag) {
+          const platformTag = handler.tags.find(tag => tag[0] == 'a' && tag[3] == platform)
+          return platformTag !== undefined
+        }
+        return false
+      })
+
+      // Get handler pubkeys from the tags
+      let handlerIds = [], i, k, handler, tag, handlerId
+      for(i=0; i<kindHandlers.length; i++) {
+        handler = kindHandlers[i]
+        for(k=0; k<handler.tags.length; k++) {
+          tag = handler.tags[k]
+          if(tag[0] == 'a' && tag[3] == platform) {
+            handlerId = tag[1].split(':')[1]
+
+            if(handlerIds.indexOf(handlerId) === -1) {
+              handlerIds.push(handlerId)
+            }
+          }
+        }
+      }
+
+      if(!this.handlerStore) {
+        this.handlerStore = useHandlerStore()
+      }
+
+      // Find matching handler objects in the store that match the pubkeys
+      const handlersToUse = []
+      for(i=0; i<handlerIds.length; i++) {
+        handlerId = handlerIds[i]
+
+        for(k in this.handlerStore.handlers) {
+          handler = this.handlerStore.handlers[k]
+
+          if(handler.pubkey == handlerId) {
+            handlersToUse.push(handler)
+          }
+        }
+      }
+
+      // Finally dig up the URL template we need.
+      let kindTag, eventTag
+      for(i=0; i<handlersToUse.length; i++) {
+        handler = handlersToUse[i]
+
+        kindTag = handler.tags.find(tag => tag[0] == 'k' && tag[1] == eventKind+'')
+        eventTag = handler.tags.find(tag => tag[0] == platform && tag[2] == linkType)
+
+        if(kindTag && eventTag) {
+          result = eventTag[1]
+          break
+        }
+      }
+    }
+
+    return result
+  }
+}

--- a/helpers/profileService.js
+++ b/helpers/profileService.js
@@ -224,11 +224,11 @@ export default {
     } else if(data.kind == 31337) {
       console.log('!!! Seeing a Zapstr track', data)
     } else if(data.kind == 31922) {
-      console.log('!!! Seeing a calendar event', data)
+      // console.log('!!! Seeing a calendar event', data)
     } else if(data.kind == 31923) {
-      console.log('!!! Seeing a calendar event', data)
+      // console.log('!!! Seeing a calendar event', data)
     } else if(data.kind == 31924) {
-      console.log('!!! Seeing a calendar', data)
+      // console.log('!!! Seeing a calendar', data)
     } else if(data.kind == 31989) {
       // console.log('!!! Seeing a handler recommendation', data)
     } else if(data.kind == 31990) {

--- a/pages/[id].vue
+++ b/pages/[id].vue
@@ -70,7 +70,7 @@ const tabInfo = ref({
 })
 
 function selectTab(value, info) {
-  // console.log('selectTab', value, info)
+  console.log('selectTab', value, info)
   activeTabId.value = value
   if(tabInfo.value[value] && info) {
     tabInfo.value[value].info = info
@@ -736,10 +736,12 @@ onMounted(() => {
               <ProfileShortNotesSummary
                 :info="shortNotesData"
                 :count="shortNotesData ? shortNotesData.length : null"
+                :handlers="handlerData"
               />
               <ProfileLongNotesSummary
                 :info="longNotesData"
                 :count="longNotesData ? longNotesData.length : null"
+                :handlers="handlerData"
               />
               <ProfileStallSummary
                 :info="stallData"
@@ -763,26 +765,31 @@ onMounted(() => {
               <ProfileLiveSummary
                 :info="liveData"
                 :count="liveData ? liveData.length : null"
+                :handlers="handlerData"
                 @navigate="selectTab"
               />
               <ProfileEventSummary
                 :info="eventsData"
                 :count="eventsData ? eventsData.length : null"
+                :handlers="handlerData"
                 @navigate="selectTab"
               />
               <ProfileCalendarSummary
                 :info="calendarData"
                 :count="calendarData ? calendarData.length : null"
+                :handlers="handlerData"
                 @navigate="selectTab"
               />
               <ProfileClassifiedsSummary
                 :info="classifiedsData"
                 :count="classifiedsData ? classifiedsData.length : null"
+                :handlers="handlerData"
                 @navigate="selectTab"
               />
               <ProfileBadgeSummary
                 :info="badgeData"
                 :count="badgeData ? badgeData.length : null"
+                :handlers="handlerData"
                 @navigate="selectTab"
               />
               <ProfileListsSummary
@@ -821,6 +828,7 @@ onMounted(() => {
               v-if="activeTabId == 'badges'" 
               :info="badgeData"
               :profileService="profileService"
+              :handlers="handlerData"
               @back="selectTab"
             />
             <ProfileRelayList 
@@ -885,21 +893,25 @@ onMounted(() => {
             <ProfileLiveTab 
               v-if="activeTabId == 'live'"
               :info="liveData"
+              :handlers="handlerData"
               @back="selectTab"
             />
             <ProfileClassifiedsTab 
               v-if="activeTabId == 'classifieds'"
               :info="classifiedsData"
+              :handlers="handlerData"
               @back="selectTab"
             />
             <ProfileEventTab 
               v-if="activeTabId == 'events'"
               :info="eventsData"
+              :handlers="handlerData"
               @back="selectTab"
             />
             <ProfileCalendarTab 
               v-if="activeTabId == 'calendars'"
               :info="calendarData"
+              :handlers="handlerData"
               @back="selectTab"
             />
             <ProfileTipsTab


### PR DESCRIPTION
This centralizes the creation of external links to other Nostr clients into a separate helper. The helper tries to see if the profile recommends a specific client for the note. If so, it uses that. If not, it uses a fallback.

Eventually, this could also consider the clients the logged-in user recommends.

The code is really messy. Just lots of looping over notes and tags. This can probably be cleaned up at some point and also be made more efficient (like identifying the preferred handler once when data comes in and not every time a link is generated). Step by step, as usual.