### PR TITLE
Performance optimization

### DIFF
--- a/components/header/relays.vue
+++ b/components/header/relays.vue
@@ -84,11 +84,21 @@ onBeforeUnmount(() => {
 const buttonTitle = computed(() => {
   return active.value ? 'Hide relays' : 'Show relays'
 })
+
+const classObject = computed(() => {
+  const c = ['header-icon-button']
+
+  if(active.value) {
+    c.push('-active')
+  }
+
+  return c.join(' ')
+})
 </script>
 
 <template>
   <button
-    class="header-icon-button"
+    :class="classObject"
     :title="buttonTitle"
     :active="active"
     @click="toggle"

--- a/components/modal/relay-item.vue
+++ b/components/modal/relay-item.vue
@@ -129,6 +129,8 @@ function onRelayDataError(error) {
   console.log('onRelayDataError', error)
 
   loadStatus.value = 'error'
+
+  relayStore.setRelayStatus(props.info.id, 'error')
 }
 
 function clickStatus(info) {

--- a/components/profile/badge/item.vue
+++ b/components/profile/badge/item.vue
@@ -160,37 +160,35 @@ onMounted(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <a
-      v-if="badgeData"
-      :class="classObject"
-      :href="link"
-      target="_blank"
-      rel="nofollow noopener noreferrer"
+  <a
+    v-if="badgeData"
+    :class="classObject"
+    :href="link"
+    target="_blank"
+    rel="nofollow noopener noreferrer"
+  >
+    <img
+      v-if="thumb && imageStatus != 'error'"
+      :src="thumb.image"
+      :alt="badgeData.name"
+      :width="thumb.width"
+      :height="thumb.height"
+      @load="imageLoaded"
+      @error="imageLoadError"
+    />
+    <div
+      v-if="!thumb || imageStatus == 'error'"
+      class="error"
     >
-      <img
-        v-if="thumb && imageStatus != 'error'"
-        :src="thumb.image"
-        :alt="badgeData.name"
-        :width="thumb.width"
-        :height="thumb.height"
-        @load="imageLoaded"
-        @error="imageLoadError"
-      />
-      <div
-        v-if="!thumb || imageStatus == 'error'"
-        class="error"
-      >
-        <p>Could not load image.</p>
-      </div>
-      <h5>{{ badgeData.name }}</h5>
-      <p>{{ badgeData.name }}</p>
-      <UiUsername
-        :publicKey="rawBadgeData.pubkey"
-        :relayIds="[rawBadgeData.relay]"
-      />
-    </a>
-  </Transition>
+      <p>Could not load image.</p>
+    </div>
+    <h5>{{ badgeData.name }}</h5>
+    <p>{{ badgeData.name }}</p>
+    <UiUsername
+      :publicKey="rawBadgeData.pubkey"
+      :relayIds="[rawBadgeData.relay]"
+    />
+  </a>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/badge/list.vue
+++ b/components/profile/badge/list.vue
@@ -17,20 +17,18 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="badge-list">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <div class="badges">
-        <ProfileBadgeItem
-          v-for="(item, index) in info"
-          :key="item.id"
-          :info="item"
-          :handlers="handlers"
-        />
-      </div>
+  <div v-if="info" class="badge-list">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <div class="badges">
+      <ProfileBadgeItem
+        v-for="(item, index) in info"
+        :key="item.id"
+        :info="item"
+        :handlers="handlers"
+      />
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/badge/summary.vue
+++ b/components/profile/badge/summary.vue
@@ -29,23 +29,21 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="badge-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
+  <div v-if="count > 0" class="badge-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <div class="badges">
+      <ProfileBadgeItem
+        v-for="(item, index) in visibleBadges"
+        :key="item.id"
+        :info="item"
+        :handlers="handlers"
       />
-      <div class="badges">
-        <ProfileBadgeItem
-          v-for="(item, index) in visibleBadges"
-          :key="item.id"
-          :info="item"
-          :handlers="handlers"
-        />
-      </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/bits/note.vue
+++ b/components/profile/bits/note.vue
@@ -283,7 +283,8 @@ function findUrlMeta(url) {
     overflow: hidden;
 
     p {
-      word-wrap: break-word;
+      // word-wrap: break-word;
+      word-break: break-word;
       color: var(--theme-text-medium);
       text-wrap: balance;
       text-overflow: ellipsis;

--- a/components/profile/calendar/summary.vue
+++ b/components/profile/calendar/summary.vue
@@ -30,20 +30,18 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="calendar-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
-      />
-      <ProfileCalendarList
-        class="items"
-        :info="visibleItems"
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="count > 0" class="calendar-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <ProfileCalendarList
+      class="items"
+      :info="visibleItems"
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/calendar/tab.vue
+++ b/components/profile/calendar/tab.vue
@@ -18,17 +18,15 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="events-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <ProfileCalendarList
-        class="items"
-        :info="info" 
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="info" class="events-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <ProfileCalendarList
+      class="items"
+      :info="info" 
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/classifieds/item.vue
+++ b/components/profile/classifieds/item.vue
@@ -71,17 +71,22 @@ const formattedDate = computed(() => {
 
 // Initial spec format is just a string, then changed to [price, number, currency, frequence]
 const price = computed(() => {
+  let result = null
+
   const price = props.info.tags.find(tag => tag[0] == 'price')
-  if(price.length == 2) {
-    return price[1]
-  } else {
-    const format = new Intl.NumberFormat(undefined, { style: 'currency', currency: price[2] })
-    let result = format.format(price[1])
-    if(price.length > 3) {
-      result += ' ' + price[3]
+  if(price) {
+    if(price.length == 2) {
+      result = price[1]
+    } else {
+      const format = new Intl.NumberFormat(undefined, { style: 'currency', currency: price[2] })
+      result = format.format(price[1])
+      if(price.length > 3) {
+        result += ' ' + price[3]
+      }
     }
-    return result
   }
+
+  return result
 })
 
 // Remote · 1000 sats per month · Jul 14

--- a/components/profile/classifieds/summary.vue
+++ b/components/profile/classifieds/summary.vue
@@ -30,20 +30,18 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="classifieds-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
-      />
-      <ProfileClassifiedsList
-        class="items"
-        :info="visibleItems"
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="count > 0" class="classifieds-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <ProfileClassifiedsList
+      class="items"
+      :info="visibleItems"
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/classifieds/tab.vue
+++ b/components/profile/classifieds/tab.vue
@@ -18,17 +18,15 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="classifieds-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <ProfileClassifiedsList
-        class="items"
-        :info="info" 
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="info" class="classifieds-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <ProfileClassifiedsList
+      class="items"
+      :info="info" 
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/event/summary.vue
+++ b/components/profile/event/summary.vue
@@ -30,20 +30,18 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="event-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
-      />
-      <ProfileEventList
-        class="items"
-        :info="visibleItems"
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="count > 0" class="event-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <ProfileEventList
+      class="items"
+      :info="visibleItems"
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/event/tab.vue
+++ b/components/profile/event/tab.vue
@@ -18,17 +18,15 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="events-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <ProfileEventList
-        class="items"
-        :info="info"
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="info" class="events-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <ProfileEventList
+      class="items"
+      :info="info"
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/file/summary.vue
+++ b/components/profile/file/summary.vue
@@ -28,22 +28,20 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="file-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
+  <div v-if="count > 0" class="file-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <div class="files">
+      <ProfileFileItem
+        v-for="(item, index) in visibleFiles"
+        :key="item.id"
+        :info="item"
       />
-      <div class="files">
-        <ProfileFileItem
-          v-for="(item, index) in visibleFiles"
-          :key="item.id"
-          :info="item"
-        />
-      </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/follow/item.vue
+++ b/components/profile/follow/item.vue
@@ -137,35 +137,33 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div class="follow-item">
-      <NuxtLink :to="profileLink">
-        <template v-if="profileContent">
-          <div :class="imageClass">
-            <img 
-              v-if="image"
-              :src="image" 
-              :alt="name"
-              @load="onImageLoaded" 
-            />
-          </div>
-          <div class="text">
-            <h3>{{ name }}</h3>
-            <p>{{ description }}</p>
-          </div>
-        </template>
-        <template v-if="!profileContent">
-          <div :class="imageClass" />
-          <div class="text">
-            <p 
-              class="-key"
-              :title="publicKey"
-            >{{ formattedPublicKey }}</p>
-          </div>
-        </template>
-      </NuxtLink>
-    </div>
-  </Transition>
+  <div class="follow-item">
+    <NuxtLink :to="profileLink">
+      <template v-if="profileContent">
+        <div :class="imageClass">
+          <img 
+            v-if="image"
+            :src="image" 
+            :alt="name"
+            @load="onImageLoaded" 
+          />
+        </div>
+        <div class="text">
+          <h3>{{ name }}</h3>
+          <p>{{ description }}</p>
+        </div>
+      </template>
+      <template v-if="!profileContent">
+        <div :class="imageClass" />
+        <div class="text">
+          <p 
+            class="-key"
+            :title="publicKey"
+          >{{ formattedPublicKey }}</p>
+        </div>
+      </template>
+    </NuxtLink>
+  </div>
 </template>
 
 <style scoped lang="scss">
@@ -180,10 +178,10 @@ onBeforeUnmount(() => {
     width: 100%;
     border-radius: 10px;
     @include r('gap', 10, 20);
-    transition: all 150ms $ease;
+    // transition: all 150ms $ease;
 
     .image {
-      background-color: rgba(black, 0.2);
+      background-color: rgba(var(--theme-front-rgb), 0.2);
       flex-basis: 50px;
       flex-shrink: 0;
       width: 50px;
@@ -196,7 +194,7 @@ onBeforeUnmount(() => {
         height: 50px;
         border-radius: 100px;
         opacity: 0;
-        transition: opacity 250ms $ease;
+        // transition: opacity 150ms $ease;
       }
 
       &.-loaded {

--- a/components/profile/follow/list.vue
+++ b/components/profile/follow/list.vue
@@ -76,11 +76,11 @@ function setupUnloadedProfiles() {
       }
     }
   }
-  // console.log('unloadedProfiles', unloadedProfiles.value, loadedProfiles.value)
+  console.log('unloadedProfiles', unloadedProfiles.value, loadedProfiles.value)
 }
 
 function onLoadProfile(data) {
-  // console.log('onLoadProfile', data)
+  console.log('onLoadProfile', data)
 
   const index = unloadedProfiles.value.indexOf(data.pubkey)
   if(index !== -1) {
@@ -100,6 +100,8 @@ if(props.info) {
 onMounted(() => {
   // console.log('FollowList.onMounted', props.profileService)
 
+  props.profileService.loadContactList()
+
   if(props.info) {
     setupUnloadedProfiles()
   }
@@ -117,31 +119,29 @@ const showLoader = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info && info.tags" class="follow-list">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <UiLoadIndicator
-        v-if="showLoader"
-      />
-      <template v-if="!showLoader">
-        <div class="items">
-          <ProfileFollowItem
-            v-for="(publicKey, index) in displayProfileList"
-            :key="publicKey"
-            :publicKey="publicKey"
-            :tag="profileTags[publicKey]"
-          />
-        </div>
-        <UiPagination
-          v-if="pageCount > 1"
-          :activeIndex="currentPage"
-          :max="pageCount"
-          @selectPage="selectPage"
+  <div v-if="info && info.tags" class="follow-list">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <UiLoadIndicator
+      v-if="showLoader"
+    />
+    <template v-if="!showLoader">
+      <div class="items">
+        <ProfileFollowItem
+          v-for="(publicKey, index) in displayProfileList"
+          :key="publicKey"
+          :publicKey="publicKey"
+          :tag="profileTags[publicKey]"
         />
-      </template>
-    </div>
-  </Transition>
+      </div>
+      <UiPagination
+        v-if="pageCount > 1"
+        :activeIndex="currentPage"
+        :max="pageCount"
+        @selectPage="selectPage"
+      />
+    </template>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/follow/summary.vue
+++ b/components/profile/follow/summary.vue
@@ -3,8 +3,7 @@ import relayManager from '@/helpers/relayManager.js'
 
 const props = defineProps([
   'info',
-  'count',
-  'baseUrl'
+  'count'
 ])
 
 const titleCopy = computed(() => {
@@ -40,7 +39,7 @@ const followerFive = computed(() => {
 function prepFollowerInfo(index) {
   let result
   let relayId
-  let relayIds
+  let relayIds = []
   let publicKey
   let tag
 
@@ -49,24 +48,50 @@ function prepFollowerInfo(index) {
     publicKey = tag[1]
   }
 
+  // console.log('prepFollowerInfo', index, tag, props.info.content)
+
   // Try to get relays
-  if(tag.length > 2) {
+  if(tag.length > 2 && tag[2] !== '') {
     // From the follow entry. Should be precise.
     relayId = relayManager.addRelayByUrl(tag[2])
-    relayIds = [relayId]
-  } else if(props.info.content.length > 0) {
-    // From the event content.
-    const relayData = JSON.parse(props.info.content)
-    relayIds = []
-    let relayUrl
-    for(relayUrl in relayData) {
-      relayId = relayManager.addRelayByUrl(relayUrl)
-      relayIds.push(relayId)
+    relayIds.push(relayId)
+  }
+  
+  if(props.info.content.length > 0) {
+    try {
+      // From the event content.
+      // Check first if we're already connected to some of the relays
+      const relayData = JSON.parse(props.info.content)
+      let relayUrl, isAdded
+      for(relayUrl in relayData) {
+        isAdded = relayManager.isAdded(relayUrl)
+        if(isAdded) {
+          relayIds.push(relayManager.addRelayByUrl(relayUrl))
+        }
+      }
+
+      const relaysToAdd = 3
+      if(relayIds.length < relaysToAdd) {
+        for(relayUrl in relayData) {
+          isAdded = relayManager.isAdded(relayUrl)
+
+          if(!isAdded)
+            relayId = relayManager.addRelayByUrl(relayUrl)
+            relayIds.push(relayId)
+
+            if(relayIds.length >= relaysToAdd) break
+        }
+      }
+    } catch(error) {
+
     }
   } else {
     // TODO: No relays provided, how do we fill this in?
   }
 
+  if(relayIds.length == 0) relayIds = null
+
+  // console.log('relayIds', relayIds)
   return  {
     publicKey,
     relayIds
@@ -88,88 +113,86 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="follow-summary">
-      <div :class="classObject">
+  <div v-if="count > 0" class="follow-summary">
+    <div :class="classObject">
+      <UiUsername
+        v-if="followerOne"
+        :key="followerOne.publicKey"
+        :publicKey="followerOne.publicKey" 
+        :relayIds="followerOne.relayIds"
+        hideName="true"
+        showAvatar="true"
+        avatarSize="huge"
+      />
+      <UiUsername
+        v-if="count > 1 && followerTwo"
+        :key="followerTwo.publicKey" 
+        :publicKey="followerTwo.publicKey" 
+        :relayIds="followerTwo.relayIds"
+        hideName="true"
+        showAvatar="true"
+        avatarSize="huge"
+      />
+      <UiUsername
+        v-if="count > 2 && followerThree"
+        :key="followerThree.publicKey"
+        :publicKey="followerThree.publicKey" 
+        :relayIds="followerThree.relayIds"
+        hideName="true"
+        showAvatar="true"
+        avatarSize="huge"
+      />
+      <UiUsername
+        v-if="count > 3 && followerFour"
+        :key="followerFour.publicKey" 
+        :publicKey="followerFour.publicKey" 
+        :relayIds="followerFour.relayIds"
+        hideName="true"
+        showAvatar="true"
+        avatarSize="huge"
+      />
+      <UiUsername
+        v-if="count > 4 && followerFive"
+        :key="followerFive.publicKey" 
+        :publicKey="followerFive.publicKey" 
+        :relayIds="followerFive.relayIds"
+        hideName="true"
+        showAvatar="true"
+        avatarSize="huge"
+      />
+    </div>
+    <div class="copy">
+      <ProfileSectionTitle
+        :title="titleCopy"
+        :clickable="true"
+        @select="navigate"
+      />
+
+      <p v-if="count > 0">
+        Including 
         <UiUsername
-          v-if="followerOne"
           :key="followerOne.publicKey"
           :publicKey="followerOne.publicKey" 
           :relayIds="followerOne.relayIds"
-          hideName="true"
-          showAvatar="true"
-          avatarSize="huge"
         />
+        <template v-if="count == 2"> and </template>
+        <template v-if="count > 2">, </template>
         <UiUsername
-          v-if="count > 1 && followerTwo"
-          :key="followerTwo.publicKey" 
+          v-if="count > 1"
+          :key="followerTwo.publicKey"
           :publicKey="followerTwo.publicKey" 
           :relayIds="followerTwo.relayIds"
-          hideName="true"
-          showAvatar="true"
-          avatarSize="huge"
         />
+        <template v-if="count > 2">, and </template>
         <UiUsername
-          v-if="count > 2 && followerThree"
+          v-if="count > 2"
           :key="followerThree.publicKey"
           :publicKey="followerThree.publicKey" 
           :relayIds="followerThree.relayIds"
-          hideName="true"
-          showAvatar="true"
-          avatarSize="huge"
-        />
-        <UiUsername
-          v-if="count > 3 && followerFour"
-          :key="followerFour.publicKey" 
-          :publicKey="followerFour.publicKey" 
-          :relayIds="followerFour.relayIds"
-          hideName="true"
-          showAvatar="true"
-          avatarSize="huge"
-        />
-        <UiUsername
-          v-if="count > 4 && followerFive"
-          :key="followerFive.publicKey" 
-          :publicKey="followerFive.publicKey" 
-          :relayIds="followerFive.relayIds"
-          hideName="true"
-          showAvatar="true"
-          avatarSize="huge"
-        />
-      </div>
-      <div class="copy">
-        <ProfileSectionTitle
-          :title="titleCopy"
-          :clickable="true"
-          @select="navigate"
-        />
-
-        <p v-if="count > 0">
-          Including 
-          <UiUsername
-            :key="followerOne.publicKey"
-            :publicKey="followerOne.publicKey" 
-            :relayIds="followerOne.relayIds"
-          />
-          <template v-if="count == 2"> and </template>
-          <template v-if="count > 2">, </template>
-          <UiUsername
-            v-if="count > 1"
-            :key="followerTwo.publicKey"
-            :publicKey="followerTwo.publicKey" 
-            :relayIds="followerTwo.relayIds"
-          />
-          <template v-if="count > 2">, and </template>
-          <UiUsername
-            v-if="count > 2"
-            :key="followerThree.publicKey"
-            :publicKey="followerThree.publicKey" 
-            :relayIds="followerThree.relayIds"
-          />.
-        </p>
-      </div>
+        />.
+      </p>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">
@@ -188,6 +211,10 @@ function navigate() {
     :deep(a) {
       position: absolute;
       top: 0;
+      width: 75px;
+      height: 75px;
+      background-color: rgba(black, 0.15);
+      border-radius: 100px;
     }
 
     > a:nth-child(2) { left: 50px; }

--- a/components/profile/handler/list.vue
+++ b/components/profile/handler/list.vue
@@ -14,18 +14,16 @@ const classObject = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" :class="classObject">
-      <ProfileHandlerItem
-        v-for="(item, appId) in info"
-        :key="appId"
-        :appId="appId"
-        :layout="layout"
-        :info="item"
-        :theme="theme"
-      />
-    </div>
-  </Transition>
+  <div v-if="info" :class="classObject">
+    <ProfileHandlerItem
+      v-for="(item, appId) in info"
+      :key="appId"
+      :appId="appId"
+      :layout="layout"
+      :info="item"
+      :theme="theme"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/handler/summary.vue
+++ b/components/profile/handler/summary.vue
@@ -84,22 +84,20 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="handler-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
+  <div v-if="count > 0" class="handler-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <div class="handlers">
+      <ProfileHandlerList 
+        :info="visibleHandlers"
+        layout="icon"
+        theme="theme"
       />
-      <div class="handlers">
-        <ProfileHandlerList 
-          :info="visibleHandlers"
-          layout="icon"
-          theme="theme"
-        />
-      </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/handler/tab.vue
+++ b/components/profile/handler/tab.vue
@@ -51,18 +51,16 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="handler-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <ProfileHandlerList
-        class="handlers"
-        :info="groupedHandlers" 
-        layout="grid"
-        theme="theme"
-      />
-    </div>
-  </Transition>
+  <div v-if="info" class="handler-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <ProfileHandlerList
+      class="handlers"
+      :info="groupedHandlers" 
+      layout="grid"
+      theme="theme"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/info.vue
+++ b/components/profile/info.vue
@@ -115,9 +115,9 @@ const isOwner = computed(() => {
 const classObject = computed(() => {
   return [
     'profile-info',
-    props.hasBanner ? '-banner' : 'no-banner',
-    image.value ? '-image' : 'no-image',
-    hasName.value ? '-name' : 'no-name'
+    props.hasBanner ? '-banner' : '-no-banner',
+    image.value ? '-image' : '-no-image',
+    hasName.value ? '-name' : '-no-name'
   ].join(' ')
 })
 
@@ -305,7 +305,7 @@ function showDataOverlay() {
   &.-no-name {
     .text {
       h1 {
-        opacity: 0.5;
+        // opacity: 0.5;
       }
     }
   }
@@ -313,6 +313,12 @@ function showDataOverlay() {
   @include media-query(small) {
     &.-no-banner {
       flex-direction: column;
+
+      .text {
+        h1 {
+          
+        }
+      }
     }
   }
 

--- a/components/profile/lists/item.vue
+++ b/components/profile/lists/item.vue
@@ -160,6 +160,10 @@ const title = computed(() => {
   let tag = props.info.tags.find(tag => tag[0] == 'title')
 
   if(!tag || tag.length == 1 || (tag.length > 1 && tag[1].length == 0)) {
+    tag = props.info.tags.find(tag => tag[0] == 'name')
+  }
+
+  if(!tag || tag.length == 1 || (tag.length > 1 && tag[1].length == 0)) {
     tag = props.info.tags.find(tag => tag[0] == 'd')
   }
 

--- a/components/profile/lists/summary.vue
+++ b/components/profile/lists/summary.vue
@@ -81,22 +81,20 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="filledLists && filledLists.length > 0" class="lists-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
-      />
-      <p v-if="emptyListCount > 0">{{ emptyListText }}</p>
-      <ProfileListsList
-        class="items"
-        :info="visibleLists"
-        :handlers="handlers"
-        layout="box"
-      />
-    </div>
-  </Transition>
+  <div v-if="filledLists && filledLists.length > 0" class="lists-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <p v-if="emptyListCount > 0">{{ emptyListText }}</p>
+    <ProfileListsList
+      class="items"
+      :info="visibleLists"
+      :handlers="handlers"
+      layout="box"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/live/summary.vue
+++ b/components/profile/live/summary.vue
@@ -30,20 +30,18 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="live-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
-      />
-      <ProfileLiveList
-        class="items"
-        :info="visibleItems"
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="count > 0" class="live-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <ProfileLiveList
+      class="items"
+      :info="visibleItems"
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/live/tab.vue
+++ b/components/profile/live/tab.vue
@@ -18,17 +18,15 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="live-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <ProfileLiveList
-        class="items"
-        :info="info" 
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="info" class="live-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <ProfileLiveList
+      class="items"
+      :info="info" 
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/long-notes/summary.vue
+++ b/components/profile/long-notes/summary.vue
@@ -27,18 +27,16 @@ const latestNote = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="long-notes-summary">
-      <ProfileSectionTitle
-        title="Latest article"
-      />
-      <ProfileLongNotesItem
-        :key="latestNote.id"
-        :info="latestNote"
-        :handlers="handlers"
-      />
-    </div>
-  </Transition>
+  <div v-if="count > 0" class="long-notes-summary">
+    <ProfileSectionTitle
+      title="Latest article"
+    />
+    <ProfileLongNotesItem
+      :key="latestNote.id"
+      :info="latestNote"
+      :handlers="handlers"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/pinstr/summary.vue
+++ b/components/profile/pinstr/summary.vue
@@ -29,19 +29,17 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="pinstr-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
-      />
-      <ProfilePinstrList
-        class="items"
-        :info="visibleItems"
-      />
-    </div>
-  </Transition>
+  <div v-if="count > 0" class="pinstr-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <ProfilePinstrList
+      class="items"
+      :info="visibleItems"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/pinstr/tab.vue
+++ b/components/profile/pinstr/tab.vue
@@ -32,16 +32,14 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="pinstr-boards-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <ProfilePinstrList
-        class="items"
-        :info="filteredBoards" 
-      />
-    </div>
-  </Transition>
+  <div v-if="info" class="pinstr-boards-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <ProfilePinstrList
+      class="items"
+      :info="filteredBoards" 
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/product/item.vue
+++ b/components/profile/product/item.vue
@@ -124,23 +124,21 @@ const hasTags = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div :class="classObject">
-      <ProfileProductItemImages :images="images" />
-      <div class="copy">
-        <h5>
-          <a
-          :href="link"
-          target="_blank"
-          rel="nofollow noopener noreferrer"
-        >{{ title }}</a>
-        </h5>
-        <p>{{ description }}</p>
-        <p>{{ meta }}</p>
-        <ProfileBitsTags :info="info" align="left" />
-      </div>
+  <div :class="classObject">
+    <ProfileProductItemImages :images="images" />
+    <div class="copy">
+      <h5>
+        <a
+        :href="link"
+        target="_blank"
+        rel="nofollow noopener noreferrer"
+      >{{ title }}</a>
+      </h5>
+      <p>{{ description }}</p>
+      <p>{{ meta }}</p>
+      <ProfileBitsTags :info="info" align="left" />
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/relay/summary.vue
+++ b/components/profile/relay/summary.vue
@@ -40,24 +40,22 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="relay-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
+  <div v-if="count > 0" class="relay-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <div class="relays">
+      <ModalRelayItem
+        v-for="(item, index) in visibleRelays"
+        :key="item.id"
+        :info="item"
+        :showStatus="true"
+        theme="theme"
       />
-      <div class="relays">
-        <ModalRelayItem
-          v-for="(item, index) in visibleRelays"
-          :key="item.id"
-          :info="item"
-          :showStatus="true"
-          theme="theme"
-        />
-      </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/report/list.vue
+++ b/components/profile/report/list.vue
@@ -16,20 +16,18 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="report-list">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <p v-if="false">Report are not checked by anyone, so make sure to see if these are valid.</p>
-      <div class="list">
-        <ProfileReportItem
-          v-for="(item, index) in info"
-          :key="item.id"
-          :info="item"
-        />
-      </div>
+  <div v-if="info" class="report-list">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <p v-if="false">Report are not checked by anyone, so make sure to see if these are valid.</p>
+    <div class="list">
+      <ProfileReportItem
+        v-for="(item, index) in info"
+        :key="item.id"
+        :info="item"
+      />
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/report/summary.vue
+++ b/components/profile/report/summary.vue
@@ -69,35 +69,33 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="report-summary">
-      <ProfileReportIcon :type="reportOne.reason" />
-      <div class="copy">
-        <ProfileSectionTitle
-          :title="titleCopy"
-          :clickable="true"
-          @select="navigate"
-        />
+  <div v-if="count > 0" class="report-summary">
+    <ProfileReportIcon :type="reportOne.reason" />
+    <div class="copy">
+      <ProfileSectionTitle
+        :title="titleCopy"
+        :clickable="true"
+        @select="navigate"
+      />
 
-        <p v-if="count > 0">
+      <p v-if="count > 0">
+        <UiUsername
+          :publicKey="reportOne.publicKey" 
+          :relayIds="reportOne.relayIds"
+        />
+        for {{ reportOne.reason }}
+        <template v-if="count > 1">
+          , 
           <UiUsername
-            :publicKey="reportOne.publicKey" 
-            :relayIds="reportOne.relayIds"
+            :publicKey="reportTwo.publicKey" 
+            :relayIds="reportTwo.relayIds"
           />
-          for {{ reportOne.reason }}
-          <template v-if="count > 1">
-            , 
-            <UiUsername
-              :publicKey="reportTwo.publicKey" 
-              :relayIds="reportTwo.relayIds"
-            />
-            for {{ reportTwo.reason }}
-          </template>
-          <template v-if="count > 2">, and more</template>.
-        </p>
-      </div>
+          for {{ reportTwo.reason }}
+        </template>
+        <template v-if="count > 2">, and more</template>.
+      </p>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/section-title.vue
+++ b/components/profile/section-title.vue
@@ -46,7 +46,7 @@ h2 {
       padding: 0;
       color: var(--theme-front);
       text-decoration: none;
-
+      text-align: left;
       padding: 7px 12px 6px 15px;
       border-radius: 15px;
       margin-left: -15px;

--- a/components/profile/short-notes/summary.vue
+++ b/components/profile/short-notes/summary.vue
@@ -54,22 +54,20 @@ const titleUrl = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="short-notes-summary">
-      <ProfileSectionTitle
-        :url="titleUrl"
-        title="Latest updates"
+  <div v-if="count > 0" class="short-notes-summary">
+    <ProfileSectionTitle
+      :url="titleUrl"
+      title="Latest updates"
+    />
+    <div class="items">
+      <ProfileShortNotesItem
+        v-for="item in latestNotes"
+        :key="item.id"
+        :info="item"
+        :handlers="handlers"
       />
-      <div class="items">
-        <ProfileShortNotesItem
-          v-for="item in latestNotes"
-          :key="item.id"
-          :info="item"
-          :handlers="handlers"
-        />
-      </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/stall/summary.vue
+++ b/components/profile/stall/summary.vue
@@ -34,25 +34,23 @@ function navigateToStall(info) {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="count > 0" class="stall-summary">
-      <ProfileSectionTitle
-        :title="titleCopy"
-        :clickable="true"
-        @select="navigate"
+  <div v-if="count > 0" class="stall-summary">
+    <ProfileSectionTitle
+      :title="titleCopy"
+      :clickable="true"
+      @select="navigate"
+    />
+    <div class="stalls">
+      <ProfileStallItem
+        v-for="(item, index) in visibleStalls"
+        :key="item.id"
+        :info="item"
+        :products="products"
+        layout="box"
+        @select="navigateToStall"
       />
-      <div class="stalls">
-        <ProfileStallItem
-          v-for="(item, index) in visibleStalls"
-          :key="item.id"
-          :info="item"
-          :products="products"
-          layout="box"
-          @select="navigateToStall"
-        />
-      </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/stall/tab.vue
+++ b/components/profile/stall/tab.vue
@@ -22,22 +22,20 @@ function navigate(info) {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="stalls-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <div class="items">
-        <ProfileStallItem
-          v-for="(item, index) in info"
-          :key="item.id"
-          :info="item"
-          :products="products"
-          layout="box"
-          @select="navigate"
-        />
-      </div>
+  <div v-if="info" class="stalls-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <div class="items">
+      <ProfileStallItem
+        v-for="(item, index) in info"
+        :key="item.id"
+        :info="item"
+        :products="products"
+        layout="box"
+        @select="navigate"
+      />
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/tips/tab.vue
+++ b/components/profile/tips/tab.vue
@@ -63,17 +63,15 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="tipList" class="tips-tab">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <p>There's a lot you can do on Nostr. Click each tip to find apps that help you do those activities.</p>
-      <ProfileTipsList
-        class="items"
-        :info="tipList" 
-      />
-    </div>
-  </Transition>
+  <div v-if="tipList" class="tips-tab">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <p>There's a lot you can do on Nostr. Click each tip to find apps that help you do those activities.</p>
+    <ProfileTipsList
+      class="items"
+      :info="tipList" 
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/zap/list.vue
+++ b/components/profile/zap/list.vue
@@ -50,27 +50,25 @@ const title = computed(() => {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="zap-list">
-      <ProfileSectionBack @select="$emit('back')" />
-      <ProfileSectionTitle :title="title" />
-      <p>Zaps are bitcoin payments to other Nostr users.</p>
-      <div class="list">
-        <ProfileZapItem
-          v-for="(item, index) in visibleZaps"
-          :key="item.id"
-          :info="item"
-          :direction="props.direction"
-        />
-      </div>
-      <UiPagination
-        v-if="pageCount > 1"
-        :activeIndex="currentPage"
-        :max="pageCount"
-        @selectPage="selectPage"
+  <div v-if="info" class="zap-list">
+    <ProfileSectionBack @select="$emit('back')" />
+    <ProfileSectionTitle :title="title" />
+    <p>Zaps are bitcoin payments to other Nostr users.</p>
+    <div class="list">
+      <ProfileZapItem
+        v-for="(item, index) in visibleZaps"
+        :key="item.id"
+        :info="item"
+        :direction="props.direction"
       />
     </div>
-  </Transition>
+    <UiPagination
+      v-if="pageCount > 1"
+      :activeIndex="currentPage"
+      :max="pageCount"
+      @selectPage="selectPage"
+    />
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/profile/zap/summary.vue
+++ b/components/profile/zap/summary.vue
@@ -207,41 +207,39 @@ function navigate() {
 </script>
 
 <template>
-  <Transition name="fade" appear>
-    <div v-if="info" class="zap-summary">
-      <ProfileZapIcon :amount="zappedAmount" />
-      <div class="copy">
-        <ProfileSectionTitle
-          :title="titleCopy"
-          :clickable="true"
-          @select="navigate"
-        />
+  <div v-if="info" class="zap-summary">
+    <ProfileZapIcon :amount="zappedAmount" />
+    <div class="copy">
+      <ProfileSectionTitle
+        :title="titleCopy"
+        :clickable="true"
+        @select="navigate"
+      />
 
-        <p v-if="uniqueRecipientEventCount > 0">
-          <template v-if="direction == 'sent'">To </template> 
-          <template v-if="direction != 'sent'">From </template> 
-          <UiUsername
-            :publicKey="recipientOne.publicKey" 
-            :relayIds="recipientOne.relayIds"
-          />
-          <template v-if="uniqueRecipientEventCount == 2"> and </template>
-          <template v-if="uniqueRecipientEventCount > 2">, </template>
-          <UiUsername
-            v-if="uniqueRecipientEventCount > 1"
-            :publicKey="recipientTwo.publicKey" 
-            :relayIds="recipientTwo.relayIds"
-          />
-          <template v-if="uniqueRecipientEventCount > 3">, </template>
-          <UiUsername
-            v-if="uniqueRecipientEventCount > 2"
-            :publicKey="recipientThree.publicKey" 
-            :relayIds="recipientThree.relayIds"
-          />
-          <template v-if="uniqueRecipientEventCount > 4">, and others</template>.
-        </p>
-      </div>
+      <p v-if="uniqueRecipientEventCount > 0">
+        <template v-if="direction == 'sent'">To </template> 
+        <template v-if="direction != 'sent'">From </template> 
+        <UiUsername
+          :publicKey="recipientOne.publicKey" 
+          :relayIds="recipientOne.relayIds"
+        />
+        <template v-if="uniqueRecipientEventCount == 2"> and </template>
+        <template v-if="uniqueRecipientEventCount > 2">, </template>
+        <UiUsername
+          v-if="uniqueRecipientEventCount > 1"
+          :publicKey="recipientTwo.publicKey" 
+          :relayIds="recipientTwo.relayIds"
+        />
+        <template v-if="uniqueRecipientEventCount > 3">, </template>
+        <UiUsername
+          v-if="uniqueRecipientEventCount > 2"
+          :publicKey="recipientThree.publicKey" 
+          :relayIds="recipientThree.relayIds"
+        />
+        <template v-if="uniqueRecipientEventCount > 4">, and others</template>.
+      </p>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped lang="scss">

--- a/components/ui/avatar.vue
+++ b/components/ui/avatar.vue
@@ -55,7 +55,7 @@ const classObject = computed(() => {
   img {
     border-radius: 143px;
     opacity: 0.2;
-    transition: all 250ms $ease;
+    // transition: all 250ms $ease;
     object-fit: cover;
   }
 

--- a/components/ui/image.vue
+++ b/components/ui/image.vue
@@ -97,7 +97,7 @@ const message = computed(() => {
     width: 100%;
     height: auto;
     opacity: 0;
-    transition: all 250ms $ease;
+    // transition: all 250ms $ease;
     object-fit: cover;
   }
 

--- a/components/ui/relay-status.vue
+++ b/components/ui/relay-status.vue
@@ -98,6 +98,7 @@ const statusText = computed(() => {
         result = 'Could not connect'
         break
       case 'connection-error':
+      case undefined:
         result = 'Connection error'
         break
     }

--- a/components/ui/username.vue
+++ b/components/ui/username.vue
@@ -28,13 +28,15 @@ const loadTimerDone = ref(false)
 const userData = ref(null)
 
 function loadUserData() {
+  // console.log('loadUserData', props.relayIds)
+  
   const filter = {
     kinds: [0],
     authors: [props.publicKey],
     limit: 1
   }
 
-  const relayIds = props.relayIds || relayStore.getAll
+  const relayIds = props.relayIds || relayStore.getRelayIds
 
   loadTimer = setTimeout(onLoadTimer, 5000)
 
@@ -195,11 +197,11 @@ onBeforeUnmount(() => {
   text-decoration: none;
   font-weight: 600;
   opacity: 0.25;
-  transition: opacity 150ms $ease;
+  // transition: opacity 150ms $ease;
   pointer-events: none;
 
   .avatar {
-    transition: all 250ms $ease;
+    // transition: all 250ms $ease;
   }
 
   &.-horizontal {

--- a/helpers/contactsService.js
+++ b/helpers/contactsService.js
@@ -38,11 +38,15 @@ export default function contactsService () {
       // Connect to provided relays
       this.relayIds = []
       if(data.content.length > 0) {
-        const relays = JSON.parse(data.content)
-        let relayId
-        for(let relayUrl in relays) {
-          relayId = relayManager.addRelayByUrl(relayUrl)
-          this.relayIds.push(relayId)
+        try {
+          const relays = JSON.parse(data.content)
+          let relayId
+          for(let relayUrl in relays) {
+            relayId = relayManager.addRelayByUrl(relayUrl)
+            this.relayIds.push(relayId)
+          }
+        } catch(error) {
+
         }
       } else {
         // Check our default relays

--- a/helpers/relayConnector.js
+++ b/helpers/relayConnector.js
@@ -1,5 +1,4 @@
 
-import relayList from '@/helpers/relayList.js'
 import relayManager from '@/helpers/relayManager.js'
 import { useEventStore } from "@/stores/events.js"
 import { useRelayStore } from "@/stores/relays.js"

--- a/helpers/relayList.js
+++ b/helpers/relayList.js
@@ -5,35 +5,40 @@ A list of well-established relays.
  */
 export default {
 
-  'damus-io': {
+  'damus-io': { // Canada
     name: 'Damus',
     url: 'wss://relay.damus.io',
     primary: true
   },
 
-  'nostr-info': {
-    name: 'Nostr.info',
-    url: 'wss://relay-nostr.info'
+  'nostr-land': { // Finland
+    name: 'Nostr land',
+    url: 'wss://eden.nostr.land'
   },
 
-  'wellorder-net': {
+  'wellorder-net': { // Germany
     name: 'Wellorder',
     url: 'wss://nostr-pub.wellorder.net'
   },
 
-  'wlvs-space': {
-    name: 'wlvs.space',
-    url: 'wss://nostr-relay.wlvs.space'
+  'snort': { // Belgium
+    name: 'Snort',
+    url: 'wss://relay.snort.social'
   },
 
-  'untethr-me': {
-    name: 'untethr.me',
-    url: 'wss://nostr-relay.untethr.me'
+  'zebedee': { // US
+    name: 'Zebedee',
+    url: 'wss://nostr.zebedee.cloud'
   },
 
-  'zaprite-io': {
-    name: 'Zaprite',
-    url: 'wss://nostr.zaprite.io'
+  'primal-net': { // Germany
+    name: 'Primal',
+    url: 'wss://relay.primal.net'
+  },
+
+  'zenon-info': { // US
+    name: 'Primal',
+    url: 'wss://nostr.zenon.info'
   }
 
 }

--- a/helpers/relayManager.js
+++ b/helpers/relayManager.js
@@ -1,6 +1,6 @@
 
 import { useRelayStore } from "@/stores/relays.js"
-
+import ToolBox from '@/helpers/toolBox'
 import relayList from '@/helpers/relayList.js'
 import relayConnector from '@/helpers/relayConnector.js'
 
@@ -27,11 +27,21 @@ export default {
     }
   },
 
+  // Connect to 3 random ideas from our initial seed list
   addInitialRelays() {
-    for(let relayId in relayList) {
+    const relayIds = []
+    for(let i in relayList) relayIds.push(i)
+    ToolBox.shuffleArray(relayIds)
+
+    let relaysToAdd = 5, i=0, relayId
+    for(let i=0; i<relayIds.length; i++) {
+      relayId = relayIds[i]
       relayList[relayId].id = relayId
 
       this.relayStore.addRelay(relayList[relayId])
+
+      relaysToAdd--
+      if(relaysToAdd < 0) break
     }
   },
 
@@ -122,7 +132,7 @@ export default {
   },
 
   connectToAllRelays() {
-    // console.log('connectToRelays')
+    console.log('connectToRelays')
     const relays = this.relayStore.getAll
     for(let relayId in relays) {
       this.connectToRelay(relayId)

--- a/helpers/toolBox.js
+++ b/helpers/toolBox.js
@@ -153,5 +153,15 @@ export default {
     }
 
     return result
+  },
+
+  shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const temp = array[i];
+      array[i] = array[j];
+      array[j] = temp;
+    }
+    return array
   }
 }

--- a/pages/[id].vue
+++ b/pages/[id].vue
@@ -438,26 +438,32 @@ function handleLoadedRecommendedRelay(data) {
 function handleLoadedRelayList(data) {
   // console.log('handleLoadedRelayList', data)
 
-  storeEvent(relayDataEvents, data)
+  const newEvent = storeEvent(relayDataEvents, data)
 
   if(!relayData.value) {
     relayData.value = []
   }
-  
-  let i, tag, relayId
-  for(i=0; i<data.tags.length; i++) {
-    tag = data.tags[i]
 
-    if(tag.length == 2 || (tag.length == 3 && tag[2] == 'write')) {
-      relayId = relayManager.addRelayByUrl(tag[1])
+  if(newEvent) {
+    let i, tag, relayId, relaysToAdd = 3
+    const tags = data.tags.filter(tag => tag[0] == 'r')
+    for(i=0; i<tags.length; i++) {
+      tag = tags[i]
 
-      if(relayData.value.indexOf(relayId) === -1) {
-        relayData.value.push(relayId)
+      if(tag.length == 2 || (tag.length == 3 && tag[2] == 'write')) {
+        relayId = relayManager.addRelayByUrl(tag[1])
 
-        if(profileService) {
-          profileService.addRelay(relayId)
+        if(relayData.value.indexOf(relayId) === -1) {
+          relayData.value.push(relayId)
+
+          if(profileService) {
+            profileService.addRelay(relayId)
+            relaysToAdd--
+          }
         }
       }
+
+      if(relaysToAdd <= 0) break
     }
   }
 }
@@ -489,6 +495,8 @@ function storeEvent(location, data) {
   if(!alreadyAdded) {
     location.value.push(data)
   }
+
+  return !alreadyAdded
 }
 
 function handleLoadedZapEvent(data) {


### PR DESCRIPTION
Two things I tried to work on.

First, looking at some of the Chrome performance analysis, it looks like transitions really slowed down the initial site render, even on my fast laptop. So I just took out all fade in transitions from the profile page modules and images. Should be a lot more snappy now.

Second, I tried to clean up relay handling a little. It's a super complex issue, but it should be a little better now. I updated the default relays, since some of them seem to have gone away. The site does not just blindly connect to all relays it encounters, but tries to cap the amount a bit better. Still think there's a ton that can be done here, but it requires more testing (and actually some methodical approach that I yet have to come up with), so I'll just put this live and keep at it.