### PR TITLE
Add tracking

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,7 +30,12 @@ export default defineNuxtConfig({
 				{ rel: 'manifest', href: '/manifest.json' }
 			],
 			script: [
-				{ src: '/lib/nostr-tools-1-12-1.js' } // npm i the lib did not work, so loading it in this way
+				{ src: '/lib/nostr-tools-1-12-1.js' }, // npm i the lib did not work, so loading it in this way
+				{ 
+					src: 'https://cloud.umami.is/script.js',
+					'data-website-id': 'f60ce998-27d4-421b-98a0-c54d38131290',
+					defer: true
+				}
 			]
 		}
 	},

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -6,6 +6,8 @@
     <p>Lots of cool stuff will be built on Nostr, but maybe not every service needs to build their own profile setup feature. Nosta could also be a place to outsource that. But we'll see. So far it's just an experiment.</p>
 
     <p>This site is a total playground and work-in-progress. It probably doesn't properly work right now. You can find the code for this website on <NuxtLink to="https://github.com/GBKS/nosta-me" target="_blank" rel="nofollow noopener noreferrer">GitHub</NuxtLink>, and you're invited to leave feedback and contribute.</p>
+
+    <p>Nosta uses <NuxtLink to="https://umami.is" target="_blank" rel="nofollow noopener noreferrer">Umami</NuxtLink> for analytics, a privacy-respecting, GDPR-compliant tracking solution. The dashboard is <NuxtLink href="https://cloud.umami.is/share/Jmc84OrAe0BFvHB8/nosta.me" target="_blank" rel="nofollow noopener noreferrer">publicly accessible here</NuxtLink>. The site did not have tracking for the longest time, but traffic has increased quite a lot and it would be good to have a rough idea what users actually do. If tracking turns out to not be useful, it will be removed again.</p>
   </div>
 </template>
 


### PR DESCRIPTION
Adds the Umami tracking script. I don't like tracking, but the traffic has really increased a lot, so much so that Netlify is charging me more for the bandwidth. I need to figure out what people do on the site in order to optimize the experience (UX and bandwidth), and hopefully tracking will help with that. The data dashboard is publicly accessible. If it turns out to be not useful, or I don't end up looking at it regularly, I'll remove it again.

Umami is pretty good with privacy and is GDRP-compliant, so no cookie banners or disclaimers are needed.