### PR TITLE
Fix for the header "/null" link issue

### DIFF
--- a/components/header/account.vue
+++ b/components/header/account.vue
@@ -7,11 +7,11 @@ const sessionStore = useSessionStore()
 const { isLoggedIn } = storeToRefs(sessionStore)
 
 const title = computed(() => {
-  return isLoggedIn ? 'View profile' : 'Sign in'
+  return isLoggedIn.value ? 'View profile' : 'Sign in'
 })
 
 const link = computed(() => {
-  return isLoggedIn ? '/'+sessionStore.publicKey : '/login/options'
+  return isLoggedIn.value ? '/'+sessionStore.publicKey : '/login/options'
 })
 </script>
 

--- a/components/header/header.vue
+++ b/components/header/header.vue
@@ -9,7 +9,9 @@
       <HeaderTheme />
       <HeaderRelays />
       <HeaderSearch />
-      <HeaderAccount />
+      <client-only>
+        <HeaderAccount />
+      </client-only>
     </div>
   </header>
 </template>


### PR DESCRIPTION
For whatever reason, the header button URL will sometimes not update to the logged-in users pubkey. I see this in the new Umami stats a good amount. Seems to be a problem with the client not updating from the server render, and also refs not being accessed by the value. Let's see if this fixes it.

[Preview](https://deploy-preview-80--regal-crostata-f23de2.netlify.app)