### PR TITLE
Switches hex to nsec in profile creation

### DIFF
--- a/data/sample-relays.json
+++ b/data/sample-relays.json
@@ -7,11 +7,6 @@
             "primary": true
         },
         {
-            "id": "nostr-land",
-            "name": "Nostr.land",
-            "url": "wss://eden.nostr.land"
-        },
-        {
             "id": "nostr-wine",
             "name": "Nostr.wine",
             "url": "wss://nostr.wine"

--- a/helpers/relayList.js
+++ b/helpers/relayList.js
@@ -11,11 +11,6 @@ export default {
     primary: true
   },
 
-  'nostr-land': { // Finland
-    name: 'Nostr land',
-    url: 'wss://eden.nostr.land'
-  },
-
   'wellorder-net': { // Germany
     name: 'Wellorder',
     url: 'wss://nostr-pub.wellorder.net'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,10 @@
     "": {
       "hasInstallScript": true,
       "dependencies": {
+        "@noble/hashes": "^1.5.0",
         "@noble/secp256k1": "^1.7.1",
         "@pinia/nuxt": "^0.4.6",
+        "@scure/base": "^1.1.9",
         "@scure/bip32": "^1.5.0",
         "@scure/bip39": "^1.4.0",
         "@vueuse/nuxt": "^9.10.0",
@@ -989,23 +991,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+    "node_modules/@noble/hashes": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
         "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
-      "engines": {
-        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1452,15 +1443,12 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip32": {
       "version": "1.5.0",
@@ -1475,25 +1463,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@scure/bip39": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
@@ -1502,25 +1471,6 @@
         "@noble/hashes": "~1.5.0",
         "@scure/base": "~1.1.8"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -4665,6 +4615,17 @@
         "@scure/base": "1.1.1"
       }
     },
+    "node_modules/light-bolt11-decoder/node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -5257,9 +5218,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.7.2.tgz",
-      "integrity": "sha512-Bq3Ug0SZFtgtL1+0wCnAe8AJtI7yx/00/a2nUug9SkhfOwlKS92Tef12iCK9FdwXw+oFZWMtRnSwcLayQso+xA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.10.1.tgz",
+      "integrity": "sha512-fnAxLi92UgyMAEw4fMEhDKzH53uBJ0WkkVPTNfX0b3bspeWWn0n5tDZtKRJbvW0wAGOPmU6LYWi/IKPOsq3p2Q==",
       "dependencies": {
         "@noble/ciphers": "^0.5.1",
         "@noble/curves": "1.2.0",
@@ -5301,6 +5262,28 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/nostr-tools/node_modules/@scure/bip32": {
       "version": "1.3.1",
@@ -9071,19 +9054,12 @@
       "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "requires": {
         "@noble/hashes": "1.5.0"
-      },
-      "dependencies": {
-        "@noble/hashes": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-          "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
-        }
       }
     },
     "@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
     },
     "@noble/secp256k1": {
       "version": "1.7.1",
@@ -9393,9 +9369,9 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
     },
     "@scure/bip32": {
       "version": "1.5.0",
@@ -9405,18 +9381,6 @@
         "@noble/curves": "~1.6.0",
         "@noble/hashes": "~1.5.0",
         "@scure/base": "~1.1.7"
-      },
-      "dependencies": {
-        "@noble/hashes": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-          "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
-        },
-        "@scure/base": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-          "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
-        }
       }
     },
     "@scure/bip39": {
@@ -9426,18 +9390,6 @@
       "requires": {
         "@noble/hashes": "~1.5.0",
         "@scure/base": "~1.1.8"
-      },
-      "dependencies": {
-        "@noble/hashes": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-          "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
-        },
-        "@scure/base": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-          "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
-        }
       }
     },
     "@trysound/sax": {
@@ -11781,6 +11733,13 @@
       "integrity": "sha512-AKvOigD2pmC8ktnn2TIqdJu0K0qk6ukUmTvHwF3JNkm8uWCqt18Ijn33A/a7gaRZ4PghJ59X+8+MXrzLKdBTmQ==",
       "requires": {
         "@scure/base": "1.1.1"
+      },
+      "dependencies": {
+        "@scure/base": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+          "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
+        }
       }
     },
     "lilconfig": {
@@ -12239,9 +12198,9 @@
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
     },
     "nostr-tools": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.7.2.tgz",
-      "integrity": "sha512-Bq3Ug0SZFtgtL1+0wCnAe8AJtI7yx/00/a2nUug9SkhfOwlKS92Tef12iCK9FdwXw+oFZWMtRnSwcLayQso+xA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.10.1.tgz",
+      "integrity": "sha512-fnAxLi92UgyMAEw4fMEhDKzH53uBJ0WkkVPTNfX0b3bspeWWn0n5tDZtKRJbvW0wAGOPmU6LYWi/IKPOsq3p2Q==",
       "requires": {
         "@noble/ciphers": "^0.5.1",
         "@noble/curves": "1.2.0",
@@ -12266,6 +12225,16 @@
               "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
             }
           }
+        },
+        "@noble/hashes": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+          "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
+        },
+        "@scure/base": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+          "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
         },
         "@scure/bip32": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "nuxt": "^3.0.0"
   },
   "dependencies": {
+    "@noble/hashes": "^1.5.0",
     "@noble/secp256k1": "^1.7.1",
     "@pinia/nuxt": "^0.4.6",
+    "@scure/base": "^1.1.9",
     "@scure/bip32": "^1.5.0",
     "@scure/bip39": "^1.4.0",
     "@vueuse/nuxt": "^9.10.0",

--- a/pages/create/private-key.vue
+++ b/pages/create/private-key.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { useProfileStore } from '@/stores/profile'
 import profileInitializer from '@/helpers/create/profileInitializer.js'
+import { hexToBytes } from '@noble/hashes/utils'
+import { nsecEncode } from 'nostr-tools/nip19'
 
 definePageMeta({
   layout: "create",
@@ -25,6 +27,11 @@ function onCopy() {
   isCopied.value = true
 }
 
+const nsec = computed(() => {
+  const privateKeyBytes = hexToBytes(store.privateKey)
+  return nsecEncode(privateKeyBytes)
+})
+
 onMounted(() => {
   store = useProfileStore()
 
@@ -44,7 +51,7 @@ onMounted(() => {
     <div class="options">
       <client-only>
         <UiCopyBox
-          :code="store.privateKey"
+          :code="nsec"
           @copy="onCopy"
         />
       </client-only>

--- a/pages/create/welcome.vue
+++ b/pages/create/welcome.vue
@@ -1,11 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { useProfileStore } from '@/stores/profile'
 import profileInitializer from '@/helpers/create/profileInitializer.js'
-
-import * as secp256k1 from '@noble/secp256k1'
-import { mnemonicToSeedSync } from '@scure/bip39'
-import { HDKey } from '@scure/bip32'
 
 definePageMeta({
   layout: "create",
@@ -13,9 +8,6 @@ definePageMeta({
     name: 'slide-right'
   },
   middleware (to, from) {
-    // console.log('welcome.from', from.name)
-    // console.log('welcome.to', to.name)
-
     if(to.name == 'create-welcome' && from.name == 'create-info') {
       to.meta.pageTransition.name = 'slide-left'
 
@@ -31,19 +23,11 @@ definePageMeta({
         from.meta.pageTransition.name = 'slide-right'
       }
     }
-    // to.meta.pageTransition.name = from.name == 'create-private-key' ? 'slide-left' : 'slide-right'
   }
 })
 
 const image = ref()
 const retinaImage = ref()
-
-function privateKeyFromSeedWords(mnemonic, passphrase) {
-  let root = HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase))
-  let privateKey = root.derive(`m/44'/1237'/0'/0/0`).privateKey
-  if (!privateKey) throw new Error('could not derive private key')
-  return secp256k1.utils.bytesToHex(privateKey)
-}
 
 async function updateImages() {
   image.value = await useAssets('/assets/images/baby-nostrich.jpg')
@@ -60,11 +44,6 @@ const imageSourceSet = computed(() => {
 
 onMounted(() => {
   updateImages()
-
-  const store = useProfileStore()
-  console.log('mounted', store.privateKey, store.publicKey)  
-  console.log('privateKey', store.privateKey == '')   
-  console.log('publicKey', store.publicKey == '')  
 
   profileInitializer.init()
 })
@@ -123,31 +102,3 @@ onBeforeRouteLeave((to, from) => {
 }
 
 </style>
-
-/*
-
-
-Welcome to priv !--
-
-welcome gets  left-leave
-Priv gets     priv-left-enter
-
-
-Priv to welcome --!
-
-priv gets     priv-left-leave
-welcome gets  left-enter
-
-
-priv to pub !--
-
-priv gets     priv-left-leave
-pub gets      pub-left-enter
-
-
-pub to priv --!
-
-pub gets      priv-left-leave
-priv gets     priv-left-enter
-
- */

--- a/server/api/nip05.ts
+++ b/server/api/nip05.ts
@@ -5,7 +5,6 @@ export default defineEventHandler((event) => {
 
   const defaultRelays = [
     "wss://brb.io",
-    "wss://eden.nostr.land",
     "wss://nos.lol",
     "wss://nostr-pub.wellorder.net",
     "wss://nostr.bitcoiner.social",


### PR DESCRIPTION
It's a standard now that clients show the nsec version of the private key to users for backup. This PR updates:
- The way that keys are generated from the mnemonic, using nostr-tools for derivation
- nsec is now shown on the private key page during the profile creation flow
- The login page was also updated accordingly (it accepts mnemonics, hex private keys, and nsec private keys)

[Check the preview](https://deploy-preview-98--regal-crostata-f23de2.netlify.app/)

Closes #87